### PR TITLE
Zarr converter

### DIFF
--- a/recOrder/io/zarr_converter.py
+++ b/recOrder/io/zarr_converter.py
@@ -244,6 +244,15 @@ class ZarrConverter:
         self.run_md5_check_sum_test()
 
     def run_md5_check_sum_test(self):
+        """
+        run MD5 check sum on two statistics files, one from zarr and one from raw data,
+        which contain mean,median,std for every image.  If the md5's are not equivalent,
+        the files are not equivalent, meaning the statistics of the images are different.
+
+        Returns
+        -------
+
+        """
 
         zarr_path = os.path.join(self.save_directory, self.save_name)
         if not zarr_path.endswith('.zarr'): zarr_path += '.zarr'

--- a/recOrder/io/zarr_converter.py
+++ b/recOrder/io/zarr_converter.py
@@ -1,0 +1,168 @@
+from pycromanager import Bridge
+import os
+import zarr
+from tqdm import tqdm
+import json
+from numcodecs import Blosc
+
+class ZarrConverter:
+
+    def __init__(self, save_directory, save_name=None):
+        self.version = 'ZC 0.0'
+        self.save_directory = save_directory
+        self.save_name = save_name
+
+        self._connect_and_setup_mm()
+
+        self.data_name = self.summary_metadata.getPrefix()
+        self.dtype = self.get_dtype()
+        self.p = self.data_provider.getMaxIndices().getP()
+        self.t = self.data_provider.getMaxIndices().getT()
+        self.c = self.data_provider.getMaxIndices().getC()
+        self.z = self.data_provider.getMaxIndices().getZ()
+        self.y = self.data_provider.getAnyImage().getHeight()
+        self.x = self.data_provider.getAnyImage().getWidth()
+        self.dim = (self.p, self.t, self.c, self.z, self.y, self.x)
+        print(f'Found Dataset {self.data_name} w/ dimensions (P, T, C, Z, Y, X): {self.dim}')
+
+        self.CoordBuilder = self.data_provider.getAnyImage().getCoords().copyBuilder()
+
+        self.metadata = dict()
+
+        self.temp_directory = os.path.join(os.path.expanduser('~'),'recOrder_temp')
+        self.temp_path = None
+        self.java_path = None
+        if not os.path.exists(self.temp_directory): os.mkdir(self.temp_directory)
+
+    def _gen_coordset(self):
+        return [(p,t,c,z) for p in range(self.p) for t in range(self.t) for c in range(self.t) for z in range(self.z)]
+
+    def _connect_and_setup_mm(self):
+        try:
+            self.bridge = Bridge(convert_camel_case=False)
+            self.mmc = self.bridge.get_core()
+            self.mm = self.bridge.get_studio()
+
+            data_viewers = self.mm.getDisplayManager().getAllDataViewers()
+            if data_viewers.size != 0:
+                raise ValueError(f'Detected {data_viewers.size()} data viewers \
+                Make sure the only dataviewer opened is your desired dataset')
+            else:
+                self.data_viewer = self.mm.getDisplayManager().getAllDataViewers().get(0)
+                self.data_provider = self.data_viewer.getDataProvider()
+                self.summary_metadata = self.data_provider.getSummaryMetadata()
+        except:
+            raise ValueError('Please make sure MM is running and the data is opened')
+
+
+    def _generate_summary_metadata(self):
+
+        self.temp_path = os.path.join(self.temp_directory, 'meta.json')
+        self.java_path = self.bridge.construct_java_object('java.io.File', args=[temp_path])
+
+        PropertyMap = self.summary_metadata.toPropertyMap()
+        PropertyMap.saveJSON(self.java_path, True, False)
+
+        f = open(self.temp_path)
+        dict_ = json.load(f)
+        f.close()
+
+        self.metadata['Summary'] = dict_
+
+    def _generate_plane_metadata(self, image):
+
+        PropertyMap = image.getMetadata().toPropertyMap()
+        PropertyMap.saveJSON(self.java_path, True, False)
+
+        f = open(self.temp_path)
+        image_metadata = json.load(f)
+        f.close()
+
+        return image_metadata
+
+    def _get_dtype(self):
+
+        return str(self.data_provider.getAnyImage().getRawPixels().dtype)
+
+    def get_image_object(self, coord):
+        self.CoordBuilder.p(coord[0])
+        self.CoordBuilder.t(coord[1])
+        self.CoordBuilder.c(coord[2])
+        self.CoordBuilder.z(coord[3])
+        mm_coord = self.CoordBuilder.build()
+
+        return self.data_provider.getImage(mm_coord)
+
+    def setup_zarr(self):
+
+        src = os.path.join(self.save_directory, self.save_name if self.save_name else self.data_name)
+
+        self.zarr_store = zarr.open(src)
+        self.array = self.zarr_store.create('array',
+                                            shape=(self.p if self.p != 0 else 1,
+                                                   self.t if self.t != 0 else 1,
+                                                   self.c if self.c != 0 else 1,
+                                                   self.z if self.z != 0 else 1,
+                                                   self.y,
+                                                   self.x),
+                                            chunk_size=(1, 1, 1, 1, self.y, self.x),
+                                            compressor=Blosc('zstd', clevel=3, shuffle=Blosc.BITSHUFFLE),
+                                            dtype=self.dtype,
+                                            read_only=True)
+
+    def run_conversion(self):
+
+        coords = self.gen_coordset()
+        bar_format = 'Status: |{bar}|{n_fmt}/{total_fmt} (Time Remaining: {remaining} s), {rate_fmt}{postfix}]'
+
+        for coord in tqdm(coords, bar_format=bar_format):
+            
+            img = self.get_image_object(coord)
+            
+            self.metadata['ImagePlaneMetadata'][f'{coord}'] = self._generate_plane_metadata(img)
+            self.array[coord[0], coord[1], coord[2], coord[3]] = img.getRawPixels().reshape(self.y, self.x)
+
+        self.zarr_store.attrs.put(self.metadata)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/scripts/convert_tiff_to_zarr.py
+++ b/scripts/convert_tiff_to_zarr.py
@@ -1,0 +1,24 @@
+from recOrder.io.zarr_converter import ZarrConverter
+import click
+
+@click.command()
+@click.option('--save_dir', required=True, type=str, help='path to the save directory')
+@click.option('--save_name', required=False, type=str, help='name to use for saving the data')
+def parse_args(save_dir, save_name):
+    """parse command line arguments and return class with the arguments"""
+
+    class Args():
+        def __init__(self, save_dir, save_name=None):
+            self.save_dir = save_dir
+            self.save_name = save_name
+
+    return Args(save_dir, save_name)
+
+def main():
+
+    Args = parse_args(standalone_mode=False)
+
+    converter = ZarrConverter(Args.save_dir, Args.save_name)
+    converter.run_conversion()
+
+

--- a/scripts/md5_check_sum.py
+++ b/scripts/md5_check_sum.py
@@ -1,0 +1,70 @@
+import hashlib
+import zarr
+import os
+import numpy as np
+import pathlib as path
+
+@click.command()
+@click.option('--zarr_path', required=True, type=str, help='path to the save directory')
+@click.option('--raw_stats_path', required=True, type=str, help='path to the statistics file of the raw data')
+def parse_args(zarr_path, raw_stats_path):
+    """parse command line arguments and return class with the arguments"""
+
+    class Args():
+        def __init__(self, zarr_path, raw_stats_path):
+            self.zarr_path = zarr_path
+            self.raw_stats_path = raw_stats_path
+
+    return Args(zarr_path, raw_stats_path)
+
+def md5(fname):
+    hash_md5 = hashlib.md5()
+    with open(fname, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            hash_md5.update(chunk)
+    return hash_md5.hexdigest()
+
+def gen_stats_file(zarr_path, save_path):
+
+    name = path.PurePath(zarr_path).name.removesuffix('.zarr')
+    file_name = os.path.join(save_path, name+'_ZarrStatistics.txt')
+    file = open(file_name, 'w')
+
+    z = zarr.open(zarr_path, 'r')['array']
+    shape = z.shape
+
+    for p in range(shape(0)):
+        for t in range(shape(1)):
+            for c in range(shape(2)):
+                for z in range(shape(3)):
+
+                    image = z[p, t, c, z]
+                    mean = np.mean(image)
+                    median = np.median(image)
+                    std = np.std(image)
+                    file.write(f'Coord: {coord}, Mean: {mean}, Median: {median}, Std: {std}\n')
+
+    file.close()
+    return file_name
+
+
+def main():
+
+    Args = parse_args(standalone_mode=False)
+
+    save_path = path.PurePath(Args.raw_stats_path).parent.name
+
+    conv_stats_path = gen_stats_file(Args.zarr_path, save_path)
+
+    raw_md5 = md5(Args.raw_stats_path)
+    converted_md5 = md5(conv_stats_path)
+
+    if raw_md5 != converted_md5:
+        print('MD5 check sum failed.  Potential Error in Conversion')
+    else:
+        print('MD5 check sum passed. Conversion successful')
+
+
+
+
+

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,8 @@ if __name__ == '__main__':
         include_package_data=True,
         entry_points={
             'console_scripts': [
-                'recOrder.reconstruct = recOrder.cli_module:main'
+                'recOrder.reconstruct = recOrder.cli_module:main',
+                'recOrder.convert = scripts.convert_tiff_to_zarr:main'
             ]
         }
     )


### PR DESCRIPTION
PR for the Zarr Converter.  Works on the basis of using an opened virtual dataset in Micromanager to grab each image / image metadata and transform it into a zarr (P, T, C, Z, Y, X) array.  

This conversion also includes post-conversion checks, including a random image comparison, where it makes sure 25% of the images have a MSE == 0 relative to the raw tiff data.  Another check includes saving the statistics for every image plane in a txt file, generating the same statistics for the zarr images, and preforming and MD5 check sum on the two files.  If the MD5's are not equivalent, that means the statistics of some of the images have diverged.  Seems to be robust against numerical innaccuracy.

One caveat to these raw data zarr stores is that they are not by default `read_only` (see github [issue](https://github.com/zarr-developers/zarr-python/issues/809)) and zarr considers it a feature to have the data easily modified.  This means that if the user doesn't specify to open the data in a ready-only mode, it is very easy to modify the arrays.  We may have to do something at the file system level to protect against this. 