### PR TITLE
Dist name to recOrder-napari to avoid PyPI conflict

### DIFF
--- a/recOrder/napari.yaml
+++ b/recOrder/napari.yaml
@@ -1,18 +1,18 @@
-name: recOrder
+name: recOrder-napari
 schema_version: 0.1.0
 contributions:
   commands:
-  - id: recOrder.MainWidget
+  - id: recOrder-napari.MainWidget
     title: Create Main Widget
     python_name: recOrder.plugin.widget.napari_plugin_entry_point:MainWidget
-  - id: recOrder.get_reader
+  - id: recOrder-napari.get_reader
     title: Read ome-zarr files
     python_name: recOrder.io._reader:napari_get_reader
   readers:
-  - command: recOrder.get_reader
+  - command: recOrder-napari.get_reader
     accepts_directories: true
     filename_patterns: ['*.zarr']
   widgets:
-  - command: recOrder.MainWidget
+  - command: recOrder-napari.MainWidget
     display_name: Main Menu
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
-name = recOrder
+name = recOrder-napari
 version = 1.0.0-beta
-author = Cameron Foltz
+author = Computational Microscopy Platform, CZ Biohub
 author_email = shalin.mehta@czbiohub.org
 url = https://github.com/mehta-lab/recOrder
 license = Chan Zuckerberg Biohub Software License


### PR DESCRIPTION
This is a hard-won attempt to change the distribution name to (`recOrder-napari`) while keeping the module name unchanged (`recOrder`) so that `import recOrder` statements still work. 

If we merge this and upload to PyPI I expect the package to appear as `recOrder-napari`. 

I tested this installation with `import`, the CLI, and the GUI as follows:

With this commit in your working directory
```
# Install fresh environement
$ conda create -n recorder python=3.7
$ conda activate recorder
$ pip install -e .

# Python import
python
>> import recOrder
# Imports correctly
>> quit()

# CLI
$ recOrder.help
# Prints help message

$ pip install napari[all]
$ napari -w recOrder-napari
# Opens napari with recOrder-napari plugin

```

Note: this is a branch from `main`, not `npe2_conversion`. I could not get `npe2_conversion` to work with CLI or GUI after a fresh install, so I decided to work from `main`. @mattersoflight we can diff before merging. 