### PR TITLE
Fix warnings when all layers are deleted: issue #113

### DIFF
--- a/recOrder/plugin/widget/main_widget.py
+++ b/recOrder/plugin/widget/main_widget.py
@@ -2644,28 +2644,30 @@ class MainWidget(QWidget):
     @pyqtSlot(int)
     def update_sat_scale(self):
         idx = self.ui.cb_saturation.currentIndex()
-        layer = self.ui.cb_saturation.itemText(idx)
-        data = self.viewer.layers[layer].data
-        min_, max_ = np.min(data), np.max(data)
-        self.ui.slider_saturation.setMinimum(min_)
-        self.ui.slider_saturation.setMaximum(max_)
-        self.ui.slider_saturation.setSingleStep((max_ - min_)/250)
-        self.ui.slider_saturation.setValue((min_, max_))
-        self.ui.le_sat_max.setText(str(np.round(max_, 3)))
-        self.ui.le_sat_min.setText(str(np.round(min_, 3)))
+        if idx != -1:
+            layer = self.ui.cb_saturation.itemText(idx)
+            data = self.viewer.layers[layer].data
+            min_, max_ = np.min(data), np.max(data)
+            self.ui.slider_saturation.setMinimum(min_)
+            self.ui.slider_saturation.setMaximum(max_)
+            self.ui.slider_saturation.setSingleStep((max_ - min_)/250)
+            self.ui.slider_saturation.setValue((min_, max_))
+            self.ui.le_sat_max.setText(str(np.round(max_, 3)))
+            self.ui.le_sat_min.setText(str(np.round(min_, 3)))
 
     @pyqtSlot(int)
     def update_value_scale(self):
         idx = self.ui.cb_value.currentIndex()
-        layer = self.ui.cb_value.itemText(idx)
-        data = self.viewer.layers[layer].data
-        min_, max_ = np.min(data), np.max(data)
-        self.ui.slider_value.setMinimum(min_)
-        self.ui.slider_value.setMaximum(max_)
-        self.ui.slider_value.setSingleStep((max_ - min_)/250)
-        self.ui.slider_value.setValue((min_, max_))
-        self.ui.le_val_max.setText(str(np.round(max_, 3)))
-        self.ui.le_val_min.setText(str(np.round(min_, 3)))
+        if idx != -1:
+            layer = self.ui.cb_value.itemText(idx)
+            data = self.viewer.layers[layer].data
+            min_, max_ = np.min(data), np.max(data)
+            self.ui.slider_value.setMinimum(min_)
+            self.ui.slider_value.setMaximum(max_)
+            self.ui.slider_value.setSingleStep((max_ - min_)/250)
+            self.ui.slider_value.setValue((min_, max_))
+            self.ui.le_val_max.setText(str(np.round(max_, 3)))
+            self.ui.le_val_min.setText(str(np.round(min_, 3)))
 
     @pyqtSlot(bool)
     def create_overlay(self):


### PR DESCRIPTION
Bug was in recOrder and an interaction between Qt and python.

When an "Orientation" or "Retardance" layer is deleted the "Display" combo boxes are corresponding sliders are updated so that the ranges are meaningful. When the last layer is deleted, the Qt combo box becomes empty and the Qt docs say that QComboBox.currentIndex() will return -1. We were using this index to index a numpy list which was causing the errors. 

Fix checks for index != -1 and skips the update if that's the case. 