### PR TITLE
Pin pycromanager and MicroManager versions

### DIFF
--- a/recOrder/plugin/widget/main_widget.py
+++ b/recOrder/plugin/widget/main_widget.py
@@ -1535,6 +1535,8 @@ class MainWidget(QWidget):
         -------
 
         """
+        RECOMMENDED_MM = '20210713'
+        ZMQ_TARGET_VERSION = '4.0.0'
         try:
             bridge = Bridge(convert_camel_case=False)
             self.mmc = bridge.get_core()
@@ -1543,8 +1545,11 @@ class MainWidget(QWidget):
             # Check MicroManager version compatibility.
             bridge._master_socket.send({"command": "connect", "debug": False}) # latest versions of pycromanager use '_main_socket'
             reply_json = bridge._master_socket.receive(timeout=500) # latest versions of pycromanager use '_main_socket'
-            if version.parse(reply_json['version']) < version.parse('4.0.0'):
-                print('WARNING: MicroManager version is incompatible with recOrder. Please upgrade to the latest tested MicroManager nightly build 20210713.')
+            zmq_mm_version = reply_json['version']
+            if zmq_mm_version != ZMQ_TARGET_VERSION:
+                upgrade_str = 'upgrade' if version.parse(zmq_mm_version) < version.parse(ZMQ_TARGET_VERSION) else 'downgrade'
+                print(("WARNING: This version of Micromanager has not been tested with recOrder.\n"
+                      f"Please {upgrade_str} to MicroManager nightly build {RECOMMENDED_MM}."))
 
             # Find and set calibration channel group
             calib_channels = ['State0', 'State1', 'State2', 'State3', 'State4']

--- a/recOrder/plugin/widget/main_widget.py
+++ b/recOrder/plugin/widget/main_widget.py
@@ -16,6 +16,7 @@ from recOrder.io.config_reader import ConfigReader, PROCESSING, PREPROCESSING, P
 from waveorder.io.reader import WaveorderReader
 from pathlib import Path, PurePath
 from napari import Viewer
+from packaging import version
 import numpy as np
 import os
 import json
@@ -1538,6 +1539,12 @@ class MainWidget(QWidget):
             bridge = Bridge(convert_camel_case=False)
             self.mmc = bridge.get_core()
             self.mm = bridge.get_studio()
+
+            # Check MicroManager version compatibility.
+            bridge._master_socket.send({"command": "connect", "debug": False}) # latest versions of pycromanager use '_main_socket'
+            reply_json = bridge._master_socket.receive(timeout=500) # latest versions of pycromanager use '_main_socket'
+            if version.parse(reply_json['version']) < version.parse('4.0.0'):
+                print('WARNING: MicroManager version is incompatible with recOrder. Please upgrade to the latest tested MicroManager nightly build 20210713.')
 
             # set calibration channel group
             calib_channels = ['State0', 'State1', 'State2', 'State3', 'State4']

--- a/recOrder/plugin/widget/main_widget.py
+++ b/recOrder/plugin/widget/main_widget.py
@@ -1546,7 +1546,7 @@ class MainWidget(QWidget):
             if version.parse(reply_json['version']) < version.parse('4.0.0'):
                 print('WARNING: MicroManager version is incompatible with recOrder. Please upgrade to the latest tested MicroManager nightly build 20210713.')
 
-            # set calibration channel group
+            # Find and set calibration channel group
             calib_channels = ['State0', 'State1', 'State2', 'State3', 'State4']
             self.ui.cb_config_group.clear()
             groups = self.mmc.getAvailableConfigGroups()
@@ -1564,11 +1564,13 @@ class MainWidget(QWidget):
                 for ch in config_list:
                     if ch not in calib_channels:
                         self.ui.cb_acq_channel.addItem(ch)
+
             if not config_group_found:
-                msg = f'No config group contains channels {calib_channels}. ' \
-                      'Please refer to the recOrder wiki on how to set up the config properly.'
+                print((f"No config group contains channels {calib_channels}.\n"
+                       "Please refer to the recOrder wiki on how to set up the config properly."))
                 self.ui.cb_config_group.setStyleSheet("border: 1px solid rgb(200,0,0);")
-                raise KeyError(msg)
+                raise KeyError
+
             self.mm_status_changed.emit(True)
         except:
             self.mm_status_changed.emit(False)

--- a/recOrder/plugin/widget/main_widget.py
+++ b/recOrder/plugin/widget/main_widget.py
@@ -1538,11 +1538,20 @@ class MainWidget(QWidget):
         RECOMMENDED_MM = '20210713'
         ZMQ_TARGET_VERSION = '4.0.0'
         try:
-            bridge = Bridge(convert_camel_case=False)
-            self.mmc = bridge.get_core()
-            self.mm = bridge.get_studio()
+            # Try to open Bridge. Requires micromanager to be open with server running.
+            # This does not fail gracefully, so I'm wrapping it in its own try-except block.
+            try:
+                bridge = Bridge(convert_camel_case=False)
+                self.mmc = bridge.get_core()
+                self.mm = bridge.get_studio()
+            except:
+                print(("Could not establish pycromanager bridge.\n"
+                       "Is micromanager open?\n"
+                       "Is Tools > Options > Run server on port 4827 checked?\n"
+                       f"Are you using nightly build {RECOMMENDED_MM}?"))
+                raise EnvironmentError
 
-            # Check MicroManager version compatibility.
+            # Warn the use if there is a MicroManager/ZMQ version mismatch
             bridge._master_socket.send({"command": "connect", "debug": False}) # latest versions of pycromanager use '_main_socket'
             reply_json = bridge._master_socket.receive(timeout=500) # latest versions of pycromanager use '_main_socket'
             zmq_mm_version = reply_json['version']

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
 	pyyaml>=5.4.1
 	PyWavelets>=1.1.1
 	waveorder>=1.0.0b0
-	pycromanager>=0.17
+	pycromanager==0.13.2
 	tqdm>=4.61.1
 	opencv-python>=4.5.3.56
 	natsort>=7.1.1


### PR DESCRIPTION
**Two changes:**
1. This addresses #115 by warning the user about MicroManager compatibility issues and explicitly recommends the 20210713 nightly build (the build we're currently using on all scopes in the lab). 
2. This downgrades and pins pycromanager to version 0.13.2, the latest version that is compatible with the MM 20210713 nightly build (ZMQ version 4.0.0). The ZMQ warnings disappear. 

Important related pycromanager discussion: https://github.com/micro-manager/pycro-manager/issues/260

Instead of the approach I'm suggesting here, @ieivanov suggested that we always pull the latest pycromanager version and manually update whichever MM install we're using by copy-pasting .jars. I tried this approach and it works, but I'm hesitant to use it because it requires managing the .jars and Henry recommended against it. 

Instead, I think we should do periodic updates like Henry suggests. We pick the latest MM version that works with our hardware and use the compatible pycromanager version. Every ~6 months, we can go through the effort of updating MM, testing our hardware, and updating pycromanager and recOrder. This means that each version of recOrder will be associated with a specific recommended version of MM and PM. 

I think one of Ivan's concerns is that we might want the latest features of MM and PM, but the MM device adaptors aren't compatible. If this is the case, then I think we should document and report the incompatibilities like Nico suggests. 

I will do more testing and wait for @ieivanov's comments (I hope I'm doing your concerns justice) before moving forward with this. 