### PR TITLE
Add ome-tiff reader to `recOrder` (via `waveorder`)

### DIFF
--- a/recOrder/io/_reader.py
+++ b/recOrder/io/_reader.py
@@ -3,8 +3,11 @@ import zarr
 from typing import Tuple, List, Dict, Union
 
 def napari_get_reader(path):
-    if isinstance(path, str) and '.zarr' in path:
-        return ome_zarr_reader
+    if isinstance(path, str):
+        if '.zarr' in path:
+            return ome_zarr_reader
+        else:
+            return ome_tif_reader
     else:
         return None
 
@@ -27,6 +30,21 @@ def ome_zarr_reader(path: Union[str, List[str]]) -> List[Tuple[zarr.Array, Dict]
         meta = dict()
         name = names[pos]
         meta['name'] = name
+        results.append((reader.get_zarr(pos), meta))
+
+    return results
+
+def ome_tif_reader(path: Union[str, List[str]]) -> List[Tuple[zarr.Array, Dict]]:
+    reader = WaveorderReader(path)
+    results = list()
+
+    npos = reader.get_num_positions()
+    for pos in range(npos):
+        meta = dict()
+        if npos == 1:
+            meta['name'] = 'Pos000_000'
+        else:
+            meta['name'] = reader.stage_positions[pos]['Label'][2:]
         results.append((reader.get_zarr(pos), meta))
 
     return results

--- a/recOrder/napari.yaml
+++ b/recOrder/napari.yaml
@@ -6,12 +6,12 @@ contributions:
     title: Create Main Widget
     python_name: recOrder.plugin.widget.napari_plugin_entry_point:MainWidget
   - id: recOrder-napari.get_reader
-    title: Read ome-zarr files
+    title: Read ome-zarr and ome-tif files
     python_name: recOrder.io._reader:napari_get_reader
   readers:
   - command: recOrder-napari.get_reader
     accepts_directories: true
-    filename_patterns: ['*.zarr']
+    filename_patterns: ['*.zarr', '*.tif']
   widgets:
   - command: recOrder-napari.MainWidget
     display_name: Main Menu

--- a/recOrder/tests/reader_tests/test_reader.py
+++ b/recOrder/tests/reader_tests/test_reader.py
@@ -1,0 +1,19 @@
+from recOrder.io._reader import napari_get_reader, ome_zarr_reader, ome_tif_reader
+import os
+from os.path import dirname, abspath
+import yaml
+
+def test_napari_get_reader(setup_test_data):
+    folder, ometiff_data, zarr_data, bf_data = setup_test_data
+    assert(napari_get_reader(ometiff_data).__name__ == 'ome_tif_reader')
+    assert(napari_get_reader(zarr_data).__name__ == 'ome_zarr_reader')
+
+def test_readers(setup_test_data):
+    folder, ometiff_data, zarr_data, bf_data = setup_test_data
+
+    data_from_ome = ome_tif_reader(ometiff_data)
+    data_from_zarr = ome_zarr_reader(zarr_data)
+
+    for data in [data_from_ome, data_from_zarr]:
+        assert(len(data) == 3)
+        assert(data[0][0].shape == (2, 4, 81, 231, 498))


### PR DESCRIPTION
This PR allows the user to drag and drop `ome.tif` files saved by micromanager into `recOrder`. Instead of forcing the user to convert to .zarr, this PR will allow the user to quickly check the result of a micromanager acquisition. 

After this PR is merged,`recOrder`'s napari reader will accept both `ome.tif` files and `.zarr` files. All of the readers call the corresponding `waveorder` readers. 

This PR includes tests on the multi-position file `2021_06_11_recOrder_pytest_20x_04NA/2T_3P_81Z_231Y_498X_Kazansky_2`. I have also tested with files that have a single position, a single z slice, a single channel, and a single time point. 

This reader strongly depends on the [`waveorder` reader](https://github.com/mehta-lab/waveorder/tree/master/waveorder/io), which includes [more comprehensive tests](https://github.com/mehta-lab/waveorder/tree/master/tests/reader). 