### PR TITLE
Fix ome-tif to zarr converter for acquisitions with micromanager beta 

### DIFF
--- a/recOrder/io/zarr_converter.py
+++ b/recOrder/io/zarr_converter.py
@@ -250,7 +250,10 @@ class ZarrConverter:
 
         for p in range(self.p):
             if self.p > 1:
-                name = self.summary_metadata['StagePositions'][p]['Label']
+                try:
+                    name = self.summary_metadata['StagePositions'][p]['Label']
+                except:
+                    name = ''
             else:
                 name = ''
             self.pos_names.append(name)
@@ -331,7 +334,6 @@ class ZarrConverter:
 
         chan_names = self._get_channel_names()
         self._get_position_names()
-
         for pos in range(self.p):
 
             clims = self.get_channel_clims(pos)

--- a/recOrder/io/zarr_converter.py
+++ b/recOrder/io/zarr_converter.py
@@ -252,7 +252,7 @@ class ZarrConverter:
             if self.p > 1:
                 try:
                     name = self.summary_metadata['StagePositions'][p]['Label']
-                except:
+                except KeyError:
                     name = ''
             else:
                 name = ''


### PR DESCRIPTION
This PR and a [parallel waveorder PR](https://github.com/mehta-lab/waveorder/pull/77) address issue #121. 

@JohannaRahm was having difficulty converting a specific `.ome.tif` file to `.zarr`, and I traced the issue to a problem with the reader for data acquired with micromanager-2.0.0-beta. The fix requires small changes to `recOrder` and `waveorder`. 

@JohannaRahm, I have successfully converted the dataset you requested and placed the result at `/hpc/projects/comp_micro/sandbox/Talon/`. @JohannaRahm can I request that you visit that location and do the following?: 

- verify that the `.zarr` has been converted appropriately for your downstream processing
- follow the detailed steps in README.txt to recreate the conversion. (Briefly, you'll create a new conda environement, checkout the appropriate `recOrder` and `waveorder` branches, then run the conversion.)
- perform more conversions in this set (and ideally others) to improve our confidence that this fix is working
- update here with any successes or failures?

If this works for your tests over the next couple days, I will merge both of these PRs and update the shared recOrder environment. 