### PR TITLE
Correct 'global' and 'local_fit' background corrections

### DIFF
--- a/recOrder/compute/qlipp_compute.py
+++ b/recOrder/compute/qlipp_compute.py
@@ -154,6 +154,7 @@ def initialize_reconstructor(pipeline, image_dim=None, wavelength_nm=None, swing
 
     print('Initializing Reconstructor...')
     start_time = time.time()
+    print(bg_correction)
     recon = waveorder_microscopy(img_dim=image_dim,
                                  lambda_illu=lambda_illu,
                                  ps=ps,
@@ -207,7 +208,7 @@ def reconstruct_qlipp_stokes(data, recon, bg_stokes=None):
     stokes_data = recon.Stokes_transform(stokes_data)
 
     # Don't do background correction if BG data isn't provided
-    if recon.bg_option == 'None' or bg_stokes is None:
+    if recon.bg_option == 'None':
         return stokes_data # C(Z)YX
 
     # Compute Stokes with background correction

--- a/recOrder/io/config_reader.py
+++ b/recOrder/io/config_reader.py
@@ -206,7 +206,7 @@ class ConfigReader(object):
                                    'Only 3D reconstructions can be performed in 3D mode')
 
             elif key == 'background_correction' and self.config['dataset']['method'] == 'QLIPP':
-                if self.config['processing'][key] == 'None' or self.config['processing'][key] == 'local_filter':
+                if self.config['processing'][key] == 'None' or self.config['processing'][key] == 'local_fit':
                     pass
                 else:
                     assert self.config['dataset']['background'] is not None, \

--- a/recOrder/io/metadata_reader.py
+++ b/recOrder/io/metadata_reader.py
@@ -38,7 +38,7 @@ class MetadataReader:
         self.Wavelength = self.get_summary_calibration_attr('Wavelength (nm)')
         self.Black_level = self.get_black_level()
         self.Extinction_ratio = self.get_extinction_ratio()
-        self.ROI = self.get_roi()
+        self.ROI = tuple(self.get_roi()) # JSON does not preserve tuples
         self.Channel_names = self.get_channel_names()
         self.LCA_retardance = self.get_lc_retardance('LCA')
         self.LCB_retardance = self.get_lc_retardance('LCB')

--- a/recOrder/pipelines/qlipp_pipeline.py
+++ b/recOrder/pipelines/qlipp_pipeline.py
@@ -79,6 +79,7 @@ class QLIPP(PipelineInterface):
                                                           wavelength_nm=self.config.wavelength,
                                                           swing=self.calib_meta.Swing,
                                                           calibration_scheme=self.calib_scheme,
+                                                          n_slices=self.data.slices,
                                                           pad_z=self.config.pad_z,
                                                           bg_correction=self.config.background_correction,
                                                           mode=self.mode,

--- a/recOrder/pipelines/qlipp_pipeline.py
+++ b/recOrder/pipelines/qlipp_pipeline.py
@@ -72,6 +72,12 @@ class QLIPP(PipelineInterface):
         self.data_shape = (self.t, len(self.output_channels), self.slices, self.img_dim[0], self.img_dim[1])
         self.chunk_size = (1, 1, 1, self.data_shape[-2], self.data_shape[-1])
 
+        # Convert 'local_fit+' to 'local_fit' for waveorder
+        if self.config.background_correction == 'local_fit+':
+            wo_background_correction = 'local_fit'
+        else:
+            wo_background_correction = self.config.background_correction
+
         # Initialize Reconstructor
         if self.no_phase:
             self.reconstructor = initialize_reconstructor(pipeline='birefringence',
@@ -81,7 +87,7 @@ class QLIPP(PipelineInterface):
                                                           calibration_scheme=self.calib_scheme,
                                                           n_slices=self.data.slices,
                                                           pad_z=self.config.pad_z,
-                                                          bg_correction=self.config.background_correction,
+                                                          bg_correction=wo_background_correction,
                                                           mode=self.mode,
                                                           use_gpu=self.config.use_gpu,
                                                           gpu_id=self.config.gpu_id)
@@ -100,22 +106,22 @@ class QLIPP(PipelineInterface):
                                                           z_step_um=self.data.z_step_size,
                                                           pad_z=self.config.pad_z,
                                                           pixel_size_um=self.config.pixel_size,
-                                                          bg_correction=self.config.background_correction,
+                                                          bg_correction=wo_background_correction,
                                                           mode=self.mode,
                                                           use_gpu=self.config.use_gpu,
                                                           gpu_id=self.config.gpu_id)
 
-        # Compute BG stokes if necessary
-        if self.config.background_correction == 'global':
-            print("Loading bg from "+self.bg_path)
+        # Prepare background corrections for waveorder
+        if self.config.background_correction in ['global', 'local_fit+']:
             bg_data = load_bg(self.bg_path, self.img_dim[0], self.img_dim[1], self.bg_roi)
             self.bg_stokes = self.reconstructor.Stokes_recon(bg_data)
             self.bg_stokes = self.reconstructor.Stokes_transform(self.bg_stokes)
         elif self.config.background_correction == 'local_fit':
             self.bg_stokes = np.zeros((5, self.img_dim[0], self.img_dim[1]))
-            self.bg_stokes[0, ...] = 1 # Set background to "identity" Stokes parameters. waveorder's 'local_fit' applies this identity correction.
+            self.bg_stokes[0, ...] = 1  # Set background to "identity" Stokes parameters.
         else:
             self.bg_stokes = None
+
 
     def _check_output_channels(self, output_channels):
         self.no_birefringence = True

--- a/recOrder/pipelines/qlipp_pipeline.py
+++ b/recOrder/pipelines/qlipp_pipeline.py
@@ -105,11 +105,14 @@ class QLIPP(PipelineInterface):
                                                           gpu_id=self.config.gpu_id)
 
         # Compute BG stokes if necessary
-        if self.config.background_correction != 'None':
+        if self.config.background_correction == 'global':
+            print("Loading bg from "+self.bg_path)
             bg_data = load_bg(self.bg_path, self.img_dim[0], self.img_dim[1], self.bg_roi)
             self.bg_stokes = self.reconstructor.Stokes_recon(bg_data)
             self.bg_stokes = self.reconstructor.Stokes_transform(self.bg_stokes)
-
+        elif self.config.background_correction == 'local_fit':
+            self.bg_stokes = np.zeros((5, self.img_dim[0], self.img_dim[1]))
+            self.bg_stokes[0, ...] = 1 # Set background to "identity" Stokes parameters. waveorder's 'local_fit' applies this identity correction.
         else:
             self.bg_stokes = None
 

--- a/recOrder/plugin/widget/main_widget.py
+++ b/recOrder/plugin/widget/main_widget.py
@@ -143,7 +143,7 @@ class MainWidget(QWidget):
         tooltips = ['No background correction.',
                     'Correct sample images with a background image acquired at an empty field of view, loaded from "Background Path".',
                     'Estimate sample background by fitting a 2D surface to the sample images. Works well when structures are spatially distributed across the field of view and a clear background is unavailable.',
-                    'Apply "Measured" background correction and then "Estimated" background correction. Use to remove residual background from "Measured"-corrected datasets.']
+                    'Apply "Measured" background correction and then "Estimated" background correction. Use to remove residual background after the sample retardance is corrected with measured background.']
         for i, bg_option in enumerate(bg_options):
             wrapped_tooltip = '\n'.join(textwrap.wrap(tooltips[i], width=70))
             self.ui.cb_bg_method.addItem(bg_option)

--- a/recOrder/plugin/widget/main_widget.py
+++ b/recOrder/plugin/widget/main_widget.py
@@ -23,6 +23,7 @@ import os
 import json
 import logging
 import pathlib
+import textwrap
 
 
 #TODO: Parse Denoising Parameters correctly from line edits
@@ -140,12 +141,13 @@ class MainWidget(QWidget):
             self.ui.cb_bg_method.removeItem(0)
         bg_options = ['None','Measured','Estimated','Measured + Estimated']
         tooltips = ['No background correction.',
-                    'Correct with a measured background from file.',
-                    'Correct with a background estimated from the raw image.',
-                    'Correct with a measured background from file then correct further with an estimated background.']
+                    'Correct sample images with a background image acquired at an empty field of view, loaded from "Background Path".',
+                    'Estimate sample background by fitting a 2D surface to the sample images. Works well when structures are spatially distributed across the field of view and a clear background is unavailable.',
+                    'Apply "Measured" background correction and then "Estimated" background correction. Use to remove residual background from "Measured"-corrected datasets.']
         for i, bg_option in enumerate(bg_options):
+            wrapped_tooltip = '\n'.join(textwrap.wrap(tooltips[i], width=70))
             self.ui.cb_bg_method.addItem(bg_option)
-            self.ui.cb_bg_method.setItemData(i, tooltips[i], Qt.ToolTipRole)
+            self.ui.cb_bg_method.setItemData(i, wrapped_tooltip, Qt.ToolTipRole)
         self.ui.cb_bg_method.currentIndexChanged[int].connect(self.enter_bg_correction)
 
         self.ui.le_bg_path.editingFinished.connect(self.enter_acq_bg_path)


### PR DESCRIPTION
`recOrder`'s background correction was not behaving in the way that I expected---see attached figure. I tested recOrder's GUI using this [test-config.yml](https://github.com/mehta-lab/recOrder/files/9264320/test-config.txt) on the zenodo data.

'local' and 'global' corrections were giving identical results while 'none' seemed to work (see first row). 

![bkg-correction](https://user-images.githubusercontent.com/9554101/182977827-8a67d0aa-3bb7-413c-90a2-54c05725fd34.png)

Three simultaneous fixes were required:

1. To fix the background correction in `recOrder` alone, I needed to use a kludge to conform to `waveorder`'s `Polscope_bg_correction` function. Specifically, `Polscope_bg_correction` requires and applies an array-based background correction no matter what background correction option you choose. To work around this for the `local` option, I supplied an "identity" background correction. 

AFAIK most users have been avoiding `Polscope_bg_correction` by applying their corrections "by hand" in scripts. I think myself, @Soorya19Pradeep, and @JohannaRahm are doing this based on scripts I've seen. I think this is a strong argument for either rewriting `Polscope_bg_correction` or refactoring this functionality, but here I'm working under the constraint of a fixed `waveorder` dependency. 

2. The 'global' background correction was averaging over the FOV even when an ROI was not supplied. 

**Details (skippable):** This bug was caused by JSON converting python tuples to lists. A tuple was compared to a list which resulted in "False" when the result should have been "True". Specifically, the `utils.bg_read` function averaged over an ROI area when it shouldn't, which in turn made recOrder's BG correction incorrect (or at least different from expected). This means that both 'local' and 'global' corrections were behaving incorrectly. 

3. Background corrections weren't propagating to 3D stacks correctly for 'local_fit'.

The `local_fit` logic in `waveorder` depends on `self.N_defocus` (L1181 `waveorder_reconstructor.py`). My first choice would be to improve `waveorder` since the background correction code should have close to zero dependencies on the constructor object...but I'm only applying fixes to `recOrder` here so I supplied more options to the `waveorder` constructor so that `self.N_defocus` is correct. 

---

The result is matching my expectations (see second row of figure), though I'd appreciate input from @ieivanov and @mattersoflight. I will test on hummingbird before merging. 

I am fine with these fixes for 0.2.0, but I would like to consider cleaning up `waveorder` for 1.0.0 because this was a challenging bug to fix and I expect the background correction code to continue to cause headaches. 
 