### PR TITLE
Require importlib-metadata

### DIFF
--- a/recOrder/tests/calibration_tests/test_calibration.py
+++ b/recOrder/tests/calibration_tests/test_calibration.py
@@ -1,0 +1,2 @@
+def test_calib_imports():
+    from recOrder.calib import Calibration, Optimization

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ install_requires =
 	superqt>=0.2.4
 	napari-ome-zarr>=0.3.2
 	qtpy
+	importlib-metadata
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
#149 was introduced by #127, and this fixes the issue. 

This error snuck by my review because I assumed `importlib_metadata` was a builtin. My bad. I'm surprised this snuck by our tests...I will look closer tomorrow morning and update the tests to catch. 

I tested a successful install by hand. Ready to merge from my perspective. 