### PR TITLE
Test calibration imports

### DIFF
--- a/recOrder/tests/calibration_tests/test_calibration.py
+++ b/recOrder/tests/calibration_tests/test_calibration.py
@@ -1,0 +1,2 @@
+def test_calib_imports():
+    from recOrder.calib import Calibration, Optimization


### PR DESCRIPTION
Test should fail in this branch from main, and should pass when I merge into `require-importlib-metadata`.

Calibration code has no unit or integration tests, so this serves as a minimal smoke test. 