### PR TITLE
Change `recOrder`s `main` to depend on the `waveorder`'s `main`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ python_requires = >=3.7
 setup_requires = setuptools_scm
 # add your package requirements here
 install_requires =
+	waveorder @ git+https://github.com/mehta-lab/waveorder
 	numpy>=1.17.4
 	scipy>=1.3.0
 	matplotlib>=3.4.3
@@ -45,7 +46,6 @@ install_requires =
 	click>=8.0.1
 	pyyaml>=5.4.1
 	PyWavelets>=1.1.1
-	waveorder>=1.0.0b0
 	pycromanager==0.13.2
 	tqdm>=4.61.1
 	opencv-python>=4.5.3.56


### PR DESCRIPTION
I am checking that the `recOrder` tests pass against the `main` HEAD of `waveorder`. 

This PR is preparing for our new `recOrder`\`waveorder` packaging plan where:

- the main branch of recOrder depends on the main branch of waveorder, and
- each release of `recOrder` depends on a specific release of `waveorder`. If a `recOrder` release candidate's tests do not pass with a released version of `waveorder`, then a new release of `waveorder` is required. 

I'm leaving in draft for now, and I'll flag when it's ready to review/merge. More documentation to come. 