### PR TITLE
Print RAM warning message in online and offline modes

### DIFF
--- a/recOrder/io/utils.py
+++ b/recOrder/io/utils.py
@@ -1,5 +1,7 @@
 import glob
 import os
+import psutil
+import textwrap
 import tifffile as tiff
 import numpy as np
 from waveorder.waveorder_reconstructor import fluorescence_microscopy, waveorder_microscopy
@@ -165,3 +167,16 @@ def get_unimodal_threshold(input_image):
             max_dist = per_dist
     assert best_threshold > -np.inf, 'Error in unimodal thresholding'
     return best_threshold
+
+def ram_message():
+    BYTES_PER_GB = 2**30
+    gb_available = psutil.virtual_memory().total / BYTES_PER_GB
+    if gb_available < 32:
+        return ' \n'.join(textwrap.wrap(
+               f'\033[91mWARNING:\033[0m recOrder reconstructions often require more than the {gb_available:.1f} ' \
+               f'GB of RAM that this computer is equipped with. We recommend starting with reconstructions of small ' \
+               f'volumes ~1000 x 1000 x 10 and working up to larger volumes while monitoring your RAM usage with '
+               f'Task Manager or htop.',
+        ))
+    else:
+        return f'{gb_available:.1f} GB of RAM is available.'

--- a/recOrder/pipelines/pipeline_manager.py
+++ b/recOrder/pipelines/pipeline_manager.py
@@ -4,7 +4,7 @@ from waveorder.io.writer import WaveorderWriter
 import time
 import os
 import shutil
-from recOrder.io.utils import MockEmitter
+from recOrder.io.utils import MockEmitter, ram_message
 from recOrder.pipelines.qlipp_pipeline import QLIPP
 from recOrder.pipelines.phase_from_bf_pipeline import PhaseFromBF
 from recOrder.pipelines.fluor_deconv_pipeline import FluorescenceDeconvolution
@@ -22,6 +22,7 @@ class PipelineManager:
     """
 
     def __init__(self, config: ConfigReader, overwrite: bool = False, emitter=MockEmitter()):
+        print(ram_message())
 
         start = time.time()
         print('Reading Data...')

--- a/recOrder/plugin/workers/acquisition_workers.py
+++ b/recOrder/plugin/workers/acquisition_workers.py
@@ -8,6 +8,7 @@ from recOrder.compute.fluorescence_compute import initialize_fluorescence_recons
     deconvolve_fluorescence_2D, calculate_background
 from recOrder.io.zarr_converter import ZarrConverter
 from recOrder.io.metadata_reader import MetadataReader, get_last_metadata_file
+from recOrder.io.utils import ram_message
 from napari.qt.threading import WorkerBaseSignals, WorkerBase
 import logging
 from waveorder.io.writer import WaveorderWriter
@@ -105,7 +106,7 @@ class BFAcquisitionWorker(WorkerBase):
         """
         Function that runs the 2D or 3D acquisition and reconstructs the data
         """
-
+        print(ram_message())
         logging.info('Running Acquisition...')
         self._check_abort()
 
@@ -471,7 +472,7 @@ class FluorescenceAcquisitionWorker(WorkerBase):
         """
         Function that runs the 2D or 3D acquisition and reconstructs the data
         """
-
+        print(ram_message())
         logging.info('Running Acquisition...')
 
         self._check_abort()
@@ -836,7 +837,7 @@ class PolarizationAcquisitionWorker(WorkerBase):
         """
         Function that runs the 2D or 3D acquisition and reconstructs the data
         """
-
+        print(ram_message())
         logging.info('Running Acquisition...')
 
         # List the Channels to acquire, if 5-state then append 5th channel

--- a/recOrder/plugin/workers/acquisition_workers.py
+++ b/recOrder/plugin/workers/acquisition_workers.py
@@ -106,7 +106,7 @@ class BFAcquisitionWorker(WorkerBase):
         """
         Function that runs the 2D or 3D acquisition and reconstructs the data
         """
-        print(ram_message())
+        logging.info(ram_message())
         logging.info('Running Acquisition...')
         self._check_abort()
 
@@ -472,7 +472,7 @@ class FluorescenceAcquisitionWorker(WorkerBase):
         """
         Function that runs the 2D or 3D acquisition and reconstructs the data
         """
-        print(ram_message())
+        logging.info(ram_message())
         logging.info('Running Acquisition...')
 
         self._check_abort()
@@ -837,7 +837,7 @@ class PolarizationAcquisitionWorker(WorkerBase):
         """
         Function that runs the 2D or 3D acquisition and reconstructs the data
         """
-        print(ram_message())
+        logging.info(ram_message())
         logging.info('Running Acquisition...')
 
         # List the Channels to acquire, if 5-state then append 5th channel


### PR DESCRIPTION
This PR prints the following message to users who request a reconstruction (via online or offline modes) when <32 GB of RAM is available:

"WARNING: recOrder reconstructions often require more than the 16 GB of RAM that this computer is equipped with. We recommend starting with reconstructions of small volumes ~1000 x 1000 x 10 and working up to larger volumes while monitoring your RAM usage with Task Manager or htop."

When >32 GB is available (e.g. 64 GB), it prints:

"64 GB of RAM is available."

I'm happy to take wording edits or completely overhaul this PR given our discussion in #108. 

Note: `psutil` is a dependency of one of our dependencies, so it is already installed in `recOrder` environments. 