### PR TITLE
CLI regression fix and end-to-end CLI test

### DIFF
--- a/recOrder/scripts/cli.py
+++ b/recOrder/scripts/cli.py
@@ -1,5 +1,6 @@
 import click
 import sys
+import os
 from recOrder.io.zarr_converter import ZarrConverter
 from recOrder.io.config_reader import ConfigReader
 from recOrder.pipelines.pipeline_manager import PipelineManager

--- a/recOrder/tests/pipeline_tests/test_qlipp_pipeline.py
+++ b/recOrder/tests/pipeline_tests/test_qlipp_pipeline.py
@@ -16,10 +16,10 @@ def test_cli_config(setup_test_data, setup_data_save_folder):
     path_to_config = os.path.abspath(os.path.join(file_path, './test_configs/qlipp/config_qlipp_full_pytest.yml'))
     zarr_data = os.path.join(setup_test_data, '2022_08_04_recOrder_pytest_20x_04NA_zarr', '2T_3P_16Z_128Y_256X_Kazansky.zarr')
 
-    result = subprocess.run(['recOrder.reconstruct', '--config', path_to_config,
-                             '--data_dir', zarr_data,
-                             '--save_dir', setup_data_save_folder],
-                            shell=True)
+    cmd_string = ' '.join(['recOrder.reconstruct', '--config', path_to_config, '--data_dir', zarr_data,
+                           '--save_dir', setup_data_save_folder])
+
+    result = subprocess.run(cmd_string, shell=True)
     assert(result.returncode == 0)
 
 def test_pipeline_manager_initiate(init_qlipp_pipeline_manager):

--- a/recOrder/tests/pipeline_tests/test_qlipp_pipeline.py
+++ b/recOrder/tests/pipeline_tests/test_qlipp_pipeline.py
@@ -18,7 +18,8 @@ def test_cli_config(setup_test_data, setup_data_save_folder):
 
     result = subprocess.run(['recOrder.reconstruct', '--config', path_to_config,
                              '--data_dir', zarr_data,
-                             '--save_dir', setup_data_save_folder])
+                             '--save_dir', setup_data_save_folder],
+                            shell=True)
     assert(result.returncode == 0)
 
 def test_pipeline_manager_initiate(init_qlipp_pipeline_manager):
@@ -168,4 +169,3 @@ def test_2D_reconstruction(get_zarr_data_dir, setup_data_save_folder):
     # Check Phase
     assert (np.sum(np.abs(phase2D - array[0, 3, 0]) ** 2) / np.sum(np.abs(phase2D)**2) < 0.1)
 
-#TODO: Add tests/test data for 5 state reconstruction?

--- a/recOrder/tests/pipeline_tests/test_qlipp_pipeline.py
+++ b/recOrder/tests/pipeline_tests/test_qlipp_pipeline.py
@@ -168,4 +168,4 @@ def test_2D_reconstruction(get_zarr_data_dir, setup_data_save_folder):
 
     # Check Phase
     assert (np.sum(np.abs(phase2D - array[0, 3, 0]) ** 2) / np.sum(np.abs(phase2D)**2) < 0.1)
-
+    #TODO: Add tests/test data for 5 state reconstruction?

--- a/recOrder/tests/pipeline_tests/test_qlipp_pipeline.py
+++ b/recOrder/tests/pipeline_tests/test_qlipp_pipeline.py
@@ -8,7 +8,18 @@ from recOrder.compute.qlipp_compute import reconstruct_qlipp_stokes, reconstruct
 from os.path import dirname, abspath
 import numpy as np
 import os
+import subprocess
 import zarr
+
+def test_cli_config(setup_test_data, setup_data_save_folder):
+    file_path = os.path.dirname(os.path.dirname(__file__))
+    path_to_config = os.path.abspath(os.path.join(file_path, './test_configs/qlipp/config_qlipp_full_pytest.yml'))
+    zarr_data = os.path.join(setup_test_data, '2022_08_04_recOrder_pytest_20x_04NA_zarr', '2T_3P_16Z_128Y_256X_Kazansky.zarr')
+
+    result = subprocess.run(['recOrder.reconstruct', '--config', path_to_config,
+                             '--data_dir', zarr_data,
+                             '--save_dir', setup_data_save_folder])
+    assert(result.returncode == 0)
 
 def test_pipeline_manager_initiate(init_qlipp_pipeline_manager):
 


### PR DESCRIPTION
I accidentally introduced a regression that broke the CLI in #133 (I failed to move `import os` into the new file). 

This PR fixes the regression and adds a test that runs the CLI in a background process and checks if it finishes successfully. This type of end-to-end test will give us more confidence that the CLI can run at all. Even though we were unit testing the functions underlying the CLI calls, the CLI was unusable and this bug made it past the tests. 