### PR TITLE
Don't delete test data?

### DIFF
--- a/recOrder/tests/conftest.py
+++ b/recOrder/tests/conftest.py
@@ -26,13 +26,6 @@ def setup_test_data():
 
     yield test_data
 
-    try:
-        # remove temp folder
-        shutil.rmtree(temp_folder)
-    except OSError as e:
-        print(f"Error while deleting temp folder: {e.strerror}")
-
-
 @pytest.fixture()
 def get_ometiff_data_dir(setup_test_data):
     test_data = setup_test_data


### PR DESCRIPTION
@ieivanov I owe an apology for deleting these lines a few months ago without much announcement, then you were likely confused and had to reintroduce them. 

I'm suggesting deleting them again because I would like to run new/modified tests locally without waiting for the test data to download. 

I'm suggesting that we keep the test data, but you may have a better solution. Is there a reason to delete them? I don't think GitHub actions complains? Is there a different workflow that you use to quickly iterate and rerun the tests without waiting for a complete download?