### PR TITLE
Check for equal exposures across channels

### DIFF
--- a/recOrder/plugin/workers/acquisition_workers.py
+++ b/recOrder/plugin/workers/acquisition_workers.py
@@ -919,7 +919,8 @@ class PolarizationAcquisitionWorker(WorkerBase):
         channel_exposures = np.array(channel_exposures)
         if not np.all(channel_exposures == channel_exposures[0]):
             # warn user that not all channels exposures were the same
-            warn_exposure_msg = 'The exposure times of each State are not equal!\nAcquiring with the exposure of State0...'
+            warn_exposure_msg = f'The MDA exposure times are not equal!\n' \
+                                f'Acquiring with State0 exposure = {channel_exposures[0]} ms.'
             show_warning(warn_exposure_msg)
 
             # setting all channel exposures to the exposure of State0

--- a/recOrder/plugin/workers/acquisition_workers.py
+++ b/recOrder/plugin/workers/acquisition_workers.py
@@ -924,10 +924,6 @@ class PolarizationAcquisitionWorker(WorkerBase):
         """
         Acquire images.
 
-        Parameters
-        ----------
-        settings:       (json) JSON dictionary conforming to MM SequenceSettings
-
         Returns
         -------
         stack:          (nd-array) Dimensions are (C, Z, Y, X). Z=1 for 2D acquisition.

--- a/recOrder/plugin/workers/acquisition_workers.py
+++ b/recOrder/plugin/workers/acquisition_workers.py
@@ -912,7 +912,7 @@ class PolarizationAcquisitionWorker(WorkerBase):
         logging.debug('Verifying exposure times...')
         # parse exposure times
         channel_exposures = []
-        for _, channel in enumerate(self.settings['channels']):
+        for channel in self.settings['channels']:
             channel_exposures.append(channel['exposure'])
 
         channel_exposures = np.array(channel_exposures)
@@ -921,8 +921,8 @@ class PolarizationAcquisitionWorker(WorkerBase):
             logging.warning('The exposure times of each State are not equal!\nAcquiring with the exposure of State0...')
 
             # setting all channel exposures to the exposure of State0
-            for i in range(len(self.settings['channels']) - 1):
-                self.settings['channels'][i + 1]['exposure'] = self.settings['channels'][0]['exposure']
+            for i in range(len(self.settings['channels'])):
+                self.settings['channels'][i]['exposure'] = self.settings['channels'][0]['exposure']
         
         self._check_abort()
 

--- a/recOrder/plugin/workers/acquisition_workers.py
+++ b/recOrder/plugin/workers/acquisition_workers.py
@@ -878,6 +878,18 @@ class PolarizationAcquisitionWorker(WorkerBase):
 
             self._check_abort()
 
+            # Check that all LF channels have the same exposure settings
+            channel_exposures = []
+            for i in range(len(settings['channels'])):
+                channel_exposures.append(settings['channels'][i]['exposure'])
+
+            channel_exposures = np.array(channel_exposures)
+            if not np.all(channel_exposures == channel_exposures[0]):
+                # TODO: warn user that not all channels exposures were the same
+                # setting all channel exposures to the exposure of State0
+                for i in range(len(settings['channels'])):
+                    settings['channels'][i]['exposure'] = channel_exposures[0]
+
             # Acquire from MDA settings uses MM MDA GUI
             # Returns (1, 4/5, Z, Y, X) array
             stack = acquire_from_settings(self.calib_window.mm, settings, grab_images=True)

--- a/recOrder/plugin/workers/acquisition_workers.py
+++ b/recOrder/plugin/workers/acquisition_workers.py
@@ -9,6 +9,7 @@ from recOrder.compute.fluorescence_compute import initialize_fluorescence_recons
 from recOrder.io.zarr_converter import ZarrConverter
 from recOrder.io.metadata_reader import MetadataReader, get_last_metadata_file
 from napari.qt.threading import WorkerBaseSignals, WorkerBase
+from napari.utils.notifications import show_warning
 import logging
 from waveorder.io.writer import WaveorderWriter
 import tifffile as tiff
@@ -918,7 +919,8 @@ class PolarizationAcquisitionWorker(WorkerBase):
         channel_exposures = np.array(channel_exposures)
         if not np.all(channel_exposures == channel_exposures[0]):
             # warn user that not all channels exposures were the same
-            logging.warning('The exposure times of each State are not equal!\nAcquiring with the exposure of State0...')
+            warn_exposure_msg = 'The exposure times of each State are not equal!\nAcquiring with the exposure of State0...'
+            show_warning(warn_exposure_msg)
 
             # setting all channel exposures to the exposure of State0
             for i in range(len(self.settings['channels'])):
@@ -943,7 +945,6 @@ class PolarizationAcquisitionWorker(WorkerBase):
 
         # Acquire from MDA settings uses MM MDA GUI
         # Returns (1, 4/5, Z, Y, X) array
-        # logging.debug("Acquisition settings: " + repr(self.settings)) # TODO: remove this line
         stack = acquire_from_settings(self.calib_window.mm, self.settings, grab_images=True)
         self._check_abort()
 

--- a/recOrder/plugin/workers/acquisition_workers.py
+++ b/recOrder/plugin/workers/acquisition_workers.py
@@ -914,7 +914,8 @@ class PolarizationAcquisitionWorker(WorkerBase):
         channel_exposures = np.array(channel_exposures)
         # check if exposure times are equal
         if not np.all(channel_exposures == channel_exposures[0]):
-            error_exposure_msg = f'The MDA exposure times are not equal! Aborting Acquisition...'
+            error_exposure_msg = f'The MDA exposure times are not equal! Aborting Acquisition.\n' \
+                                 f'Please manually set the exposure times to the same value from the MDA menu.'
 
             raise ValueError(error_exposure_msg)        
 


### PR DESCRIPTION
This PR fixes #110, and was split from #160 (started by @ieivanov). 

This change checks for equality of exposure time across channels. If the exposures are not equal it uses the exposure associated with State0 and TODO: warns the user. 

This initial implementation only applies to 3D birefringence acquisitions. TODO: the final implementation should apply to all birefringence acquisitions. 