### PR TITLE
Fix background correction for non-square images and online mode

### DIFF
--- a/recOrder/io/utils.py
+++ b/recOrder/io/utils.py
@@ -72,7 +72,7 @@ def load_bg(bg_path, height, width, ROI=None):
     for i in range(len(bg_paths)):
         img = tiff.imread(bg_paths[i])
 
-        if ROI is not None and ROI != (0, 0, height, width):
+        if ROI is not None and ROI != (0, 0, width, height):
             bg_data[i, :, :] = np.mean(img[ROI[1]:ROI[1] + ROI[3], ROI[0]:ROI[0] + ROI[2]])
 
         else:

--- a/recOrder/io/utils.py
+++ b/recOrder/io/utils.py
@@ -165,3 +165,21 @@ def get_unimodal_threshold(input_image):
             max_dist = per_dist
     assert best_threshold > -np.inf, 'Error in unimodal thresholding'
     return best_threshold
+def rec_bkg_to_wo_bkg(recorder_option) -> str:
+    """
+    Converts recOrder's background options to waveorder's background options.
+
+    Parameters
+    ----------
+    recorder_option
+
+    Returns
+    -------
+    waveorder_option
+
+    """
+    if recorder_option == 'local_fit+':
+        return 'local_fit'
+    else:
+        return recorder_option
+

--- a/recOrder/pipelines/qlipp_pipeline.py
+++ b/recOrder/pipelines/qlipp_pipeline.py
@@ -2,7 +2,7 @@ from recOrder.io.config_reader import ConfigReader
 from waveorder.io.reader import WaveorderReader
 from waveorder.io.writer import WaveorderWriter
 from recOrder.io import MetadataReader
-from recOrder.io.utils import load_bg, MockEmitter
+from recOrder.io.utils import load_bg, MockEmitter, rec_bkg_to_wo_bkg
 from recOrder.compute.qlipp_compute import reconstruct_qlipp_birefringence, reconstruct_qlipp_stokes, \
     reconstruct_phase2D, reconstruct_phase3D, initialize_reconstructor
 import numpy as np
@@ -72,13 +72,9 @@ class QLIPP(PipelineInterface):
         self.data_shape = (self.t, len(self.output_channels), self.slices, self.img_dim[0], self.img_dim[1])
         self.chunk_size = (1, 1, 1, self.data_shape[-2], self.data_shape[-1])
 
-        # Convert 'local_fit+' to 'local_fit' for waveorder
-        if self.config.background_correction == 'local_fit+':
-            wo_background_correction = 'local_fit'
-        else:
-            wo_background_correction = self.config.background_correction
+        wo_background_correction = rec_bkg_to_wo_bkg(self.config.background_correction)
 
-        # Initialize Reconstructor
+         # Initialize Reconstructor
         if self.no_phase:
             self.reconstructor = initialize_reconstructor(pipeline='birefringence',
                                                           image_dim=(self.img_dim[0], self.img_dim[1]),
@@ -121,7 +117,6 @@ class QLIPP(PipelineInterface):
             self.bg_stokes[0, ...] = 1  # Set background to "identity" Stokes parameters.
         else:
             self.bg_stokes = None
-
 
     def _check_output_channels(self, output_channels):
         self.no_birefringence = True

--- a/recOrder/pipelines/qlipp_pipeline.py
+++ b/recOrder/pipelines/qlipp_pipeline.py
@@ -74,7 +74,7 @@ class QLIPP(PipelineInterface):
 
         wo_background_correction = rec_bkg_to_wo_bkg(self.config.background_correction)
 
-         # Initialize Reconstructor
+        # Initialize Reconstructor
         if self.no_phase:
             self.reconstructor = initialize_reconstructor(pipeline='birefringence',
                                                           image_dim=(self.img_dim[0], self.img_dim[1]),

--- a/recOrder/plugin/widget/main_widget.py
+++ b/recOrder/plugin/widget/main_widget.py
@@ -769,7 +769,7 @@ class MainWidget(QWidget):
                 raise_error = True
                 self._set_tab_red('General', True)
 
-            if self.bg_option == 'local_fit' or self.bg_option == 'local_fit+' or self.bg_option == 'Global':
+            if self.bg_option == 'local_fit' or self.bg_option == 'local_fit+' or self.bg_option == 'global':
                 success = self._check_line_edit('bg_path')
                 if not success:
                     raise_error = True
@@ -1376,7 +1376,7 @@ class MainWidget(QWidget):
         self.bg_option = self.config_reader.background_correction
         if self.bg_option == 'None':
             self.ui.cb_bg_method.setCurrentIndex(0)
-        elif self.bg_option == 'Global':
+        elif self.bg_option == 'global':
             self.ui.cb_bg_method.setCurrentIndex(1)
         elif self.bg_option == 'local_fit':
             self.ui.cb_bg_method.setCurrentIndex(2)
@@ -2117,7 +2117,7 @@ class MainWidget(QWidget):
             self.ui.label_bg_path.setHidden(False)
             self.ui.le_bg_path.setHidden(False)
             self.ui.qbutton_browse_bg_path.setHidden(False)
-            self.bg_option = 'Global'
+            self.bg_option = 'global'
         elif state == 2:
             self.ui.label_bg_path.setHidden(True)
             self.ui.le_bg_path.setHidden(True)

--- a/recOrder/plugin/workers/acquisition_workers.py
+++ b/recOrder/plugin/workers/acquisition_workers.py
@@ -8,6 +8,7 @@ from recOrder.compute.fluorescence_compute import initialize_fluorescence_recons
     deconvolve_fluorescence_2D, calculate_background
 from recOrder.io.zarr_converter import ZarrConverter
 from recOrder.io.metadata_reader import MetadataReader, get_last_metadata_file
+from recOrder.io.utils import rec_bkg_to_wo_bkg
 from napari.qt.threading import WorkerBaseSignals, WorkerBase
 import logging
 from waveorder.io.writer import WaveorderWriter
@@ -926,6 +927,8 @@ class PolarizationAcquisitionWorker(WorkerBase):
 
         self._check_abort()
 
+        wo_background_correction = rec_bkg_to_wo_bkg(self.calib_window.bg_option)
+
         # Initialize the heavy reconstuctor
         if self.mode == 'phase' or self.mode == 'all':
 
@@ -948,7 +951,7 @@ class PolarizationAcquisitionWorker(WorkerBase):
                                                  z_step_um=self.calib_window.z_step,
                                                  pad_z=self.calib_window.pad_z,
                                                  pixel_size_um=self.calib_window.ps,
-                                                 bg_correction=self.calib_window.bg_option,
+                                                 bg_correction=wo_background_correction,
                                                  n_obj_media=self.calib_window.n_media,
                                                  mode=self.calib_window.phase_dim,
                                                  use_gpu=self.calib_window.use_gpu,
@@ -977,7 +980,7 @@ class PolarizationAcquisitionWorker(WorkerBase):
                                                      z_step_um=self.calib_window.z_step,
                                                      pad_z=self.calib_window.pad_z,
                                                      pixel_size_um=self.calib_window.ps,
-                                                     bg_correction=self.calib_window.bg_option,
+                                                     bg_correction=wo_background_correction,
                                                      n_obj_media=self.calib_window.n_media,
                                                      mode=self.calib_window.phase_dim,
                                                      use_gpu=self.calib_window.use_gpu,
@@ -1000,11 +1003,12 @@ class PolarizationAcquisitionWorker(WorkerBase):
                                              calibration_scheme=self.calib_window.calib_scheme,
                                              wavelength_nm=self.calib_window.wavelength,
                                              swing=self.calib_window.swing,
-                                             bg_correction=self.calib_window.bg_option,
+                                             bg_correction=wo_background_correction,
                                              n_slices=self.n_slices)
 
-        # Check to see if background correction is desired and compute BG stokes
-        if self.calib_window.bg_option != 'None':
+        # Prepare background corrections for waveorder
+        # This block mimics qlipp_pipeline.py L110-119.
+        if self.calib_window.bg_option in ['global', 'local_fit+']:
             logging.debug('Loading BG Data')
             self._check_abort()
             bg_data = self._load_bg(self.calib_window.acq_bg_directory, stack.shape[-2], stack.shape[-1])
@@ -1013,6 +1017,9 @@ class PolarizationAcquisitionWorker(WorkerBase):
             self._check_abort()
             bg_stokes = recon.Stokes_transform(bg_stokes)
             self._check_abort()
+        elif self.calib_window.bg_option == 'local_fit':
+            bg_stokes = np.zeros((5, stack.shape[-2], stack.shape[-1]))
+            bg_stokes[0, ...] = 1  # Set background to "identity" Stokes parameters.
         else:
             logging.debug('No Background Correction method chosen')
             bg_stokes = None


### PR DESCRIPTION
This PR fixes background correction bugs for:
- non-square cameras --- the `load_bg` function contained a bug that caused non-square images to apply a constant background correction instead of a pixel-wise background correction. This bug affected automaton and Yuming's setup (Oryx cameras), but not hummingbird which is why this bug slipped by previous tests. 
- online mode --- online results now match offline results in 'Estimated' and 'Measured + Estimated' modes. Currently, the online and offline modes use different section of the code for background correction, and this PR brings these sections into sync. 

I tested these fixes on automaton, and I will merge after code review. 

I'll test more thoroughly on hummingbird in advance of our 0.2.0 release. 