### PR TITLE
Remove background averaging 

### DIFF
--- a/recOrder/io/utils.py
+++ b/recOrder/io/utils.py
@@ -52,14 +52,13 @@ def extract_reconstruction_parameters(reconstructor, magnification=None):
     return attr_dict
 
 
-def load_bg(bg_path, height, width, ROI=None):
+def load_bg(bg_path, height, width):
     """
     Parameters
     ----------
     bg_path         : (str) path to the folder containing background images
     height          : (int) height of image in pixels
     width           : (int) width of image in pixels
-    ROI             : (tuple)  ROI of the background images to use, if None, full FOV will be used
 
     Returns
     -------
@@ -72,15 +71,7 @@ def load_bg(bg_path, height, width, ROI=None):
 
     for i in range(len(bg_paths)):
         img = tiff.imread(bg_paths[i])
-
-        if ROI is not None and ROI != (0, 0, width, height):
-            msg = "Warning: the background is being averaged over the ROI."
-            show_warning(msg)
-            print(msg)
-            bg_data[i, :, :] = np.mean(img[ROI[1]:ROI[1] + ROI[3], ROI[0]:ROI[0] + ROI[2]])
-
-        else:
-            bg_data[i, :, :] = img
+        bg_data[i, :, :] = img
 
     return bg_data
 

--- a/recOrder/io/utils.py
+++ b/recOrder/io/utils.py
@@ -2,6 +2,7 @@ import glob
 import os
 import tifffile as tiff
 import numpy as np
+from napari.utils.notifications import show_warning
 from waveorder.waveorder_reconstructor import fluorescence_microscopy, waveorder_microscopy
 
 

--- a/recOrder/io/utils.py
+++ b/recOrder/io/utils.py
@@ -2,6 +2,7 @@ import glob
 import os
 import tifffile as tiff
 import numpy as np
+from napari.utils.notifications import show_warning
 from waveorder.waveorder_reconstructor import fluorescence_microscopy, waveorder_microscopy
 
 
@@ -73,6 +74,9 @@ def load_bg(bg_path, height, width, ROI=None):
         img = tiff.imread(bg_paths[i])
 
         if ROI is not None and ROI != (0, 0, width, height):
+            msg = "Warning: the background is being averaged over the ROI."
+            show_warning(msg)
+            print(msg)
             bg_data[i, :, :] = np.mean(img[ROI[1]:ROI[1] + ROI[3], ROI[0]:ROI[0] + ROI[2]])
 
         else:

--- a/recOrder/io/utils.py
+++ b/recOrder/io/utils.py
@@ -2,7 +2,6 @@ import glob
 import os
 import tifffile as tiff
 import numpy as np
-from napari.utils.notifications import show_warning
 from waveorder.waveorder_reconstructor import fluorescence_microscopy, waveorder_microscopy
 
 
@@ -73,12 +72,12 @@ def load_bg(bg_path, height, width, ROI=None):
     for i in range(len(bg_paths)):
         img = tiff.imread(bg_paths[i])
 
-        if ROI is not None and ROI != (0, 0, width, height):
-            msg = "Warning: the background is being averaged over the ROI."
-            show_warning(msg)
-            print(msg)
-            bg_data[i, :, :] = np.mean(img[ROI[1]:ROI[1] + ROI[3], ROI[0]:ROI[0] + ROI[2]])
-
+        if ROI is not None and ROI != (0, 0, width, height): # TODO: Remove for 1.0.0
+            warning_msg = """
+            Warning: earlier versions of recOrder would have averaged over the background ROI. This behavior is 
+            now considered a bug, and future versions of recOrder will not average over the background. 
+            """
+            print(warning_msg)
         else:
             bg_data[i, :, :] = img
 

--- a/recOrder/io/utils.py
+++ b/recOrder/io/utils.py
@@ -52,13 +52,14 @@ def extract_reconstruction_parameters(reconstructor, magnification=None):
     return attr_dict
 
 
-def load_bg(bg_path, height, width):
+def load_bg(bg_path, height, width, ROI=None):
     """
     Parameters
     ----------
     bg_path         : (str) path to the folder containing background images
     height          : (int) height of image in pixels
     width           : (int) width of image in pixels
+    ROI             : (tuple)  ROI of the background images to use, if None, full FOV will be used
 
     Returns
     -------
@@ -71,7 +72,15 @@ def load_bg(bg_path, height, width):
 
     for i in range(len(bg_paths)):
         img = tiff.imread(bg_paths[i])
-        bg_data[i, :, :] = img
+
+        if ROI is not None and ROI != (0, 0, width, height):
+            msg = "Warning: the background is being averaged over the ROI."
+            show_warning(msg)
+            print(msg)
+            bg_data[i, :, :] = np.mean(img[ROI[1]:ROI[1] + ROI[3], ROI[0]:ROI[0] + ROI[2]])
+
+        else:
+            bg_data[i, :, :] = img
 
     return bg_data
 

--- a/recOrder/io/utils.py
+++ b/recOrder/io/utils.py
@@ -2,7 +2,6 @@ import glob
 import os
 import tifffile as tiff
 import numpy as np
-from napari.utils.notifications import show_warning
 from waveorder.waveorder_reconstructor import fluorescence_microscopy, waveorder_microscopy
 
 

--- a/recOrder/io/utils.py
+++ b/recOrder/io/utils.py
@@ -1,4 +1,5 @@
 import glob
+import logging
 import os
 import tifffile as tiff
 import numpy as np
@@ -77,7 +78,7 @@ def load_bg(bg_path, height, width, ROI=None):
             Warning: earlier versions of recOrder would have averaged over the background ROI. This behavior is 
             now considered a bug, and future versions of recOrder will not average over the background. 
             """
-            print(warning_msg)
+            logging.warning(warning_msg)
         else:
             bg_data[i, :, :] = img
 

--- a/recOrder/pipelines/qlipp_pipeline.py
+++ b/recOrder/pipelines/qlipp_pipeline.py
@@ -57,11 +57,9 @@ class QLIPP(PipelineInterface):
         if self.config.calibration_metadata:
             self.calib_meta = MetadataReader(self.config.calibration_metadata)
             self.calib_scheme = self.calib_meta.Calibration_scheme
-            self.bg_roi = self.calib_meta.ROI
         else:
             self.calib_meta = None
             self.calib_scheme = '4-State'
-            self.bg_roi = None
 
         # identify the image indicies corresponding to each polarization orientation
         self.s0_idx, self.s1_idx, \
@@ -109,7 +107,7 @@ class QLIPP(PipelineInterface):
 
         # Prepare background corrections for waveorder
         if self.config.background_correction in ['global', 'local_fit+']:
-            bg_data = load_bg(self.bg_path, self.img_dim[0], self.img_dim[1], self.bg_roi)
+            bg_data = load_bg(self.bg_path, self.img_dim[0], self.img_dim[1])
             self.bg_stokes = self.reconstructor.Stokes_recon(bg_data)
             self.bg_stokes = self.reconstructor.Stokes_transform(self.bg_stokes)
         elif self.config.background_correction == 'local_fit':

--- a/recOrder/pipelines/qlipp_pipeline.py
+++ b/recOrder/pipelines/qlipp_pipeline.py
@@ -57,9 +57,11 @@ class QLIPP(PipelineInterface):
         if self.config.calibration_metadata:
             self.calib_meta = MetadataReader(self.config.calibration_metadata)
             self.calib_scheme = self.calib_meta.Calibration_scheme
+            self.bg_roi = self.calib_meta.ROI
         else:
             self.calib_meta = None
             self.calib_scheme = '4-State'
+            self.bg_roi = None
 
         # identify the image indicies corresponding to each polarization orientation
         self.s0_idx, self.s1_idx, \
@@ -107,7 +109,7 @@ class QLIPP(PipelineInterface):
 
         # Prepare background corrections for waveorder
         if self.config.background_correction in ['global', 'local_fit+']:
-            bg_data = load_bg(self.bg_path, self.img_dim[0], self.img_dim[1])
+            bg_data = load_bg(self.bg_path, self.img_dim[0], self.img_dim[1], self.bg_roi)
             self.bg_stokes = self.reconstructor.Stokes_recon(bg_data)
             self.bg_stokes = self.reconstructor.Stokes_transform(self.bg_stokes)
         elif self.config.background_correction == 'local_fit':

--- a/recOrder/pipelines/qlipp_pipeline.py
+++ b/recOrder/pipelines/qlipp_pipeline.py
@@ -57,11 +57,11 @@ class QLIPP(PipelineInterface):
         if self.config.calibration_metadata:
             self.calib_meta = MetadataReader(self.config.calibration_metadata)
             self.calib_scheme = self.calib_meta.Calibration_scheme
-            self.bg_roi = self.calib_meta.ROI
+            self.bg_roi = self.calib_meta.ROI # TODO: remove for 1.0.0
         else:
             self.calib_meta = None
             self.calib_scheme = '4-State'
-            self.bg_roi = None
+            self.bg_roi = None # TODO: remove for 1.0.0
 
         # identify the image indicies corresponding to each polarization orientation
         self.s0_idx, self.s1_idx, \
@@ -109,7 +109,7 @@ class QLIPP(PipelineInterface):
 
         # Prepare background corrections for waveorder
         if self.config.background_correction in ['global', 'local_fit+']:
-            bg_data = load_bg(self.bg_path, self.img_dim[0], self.img_dim[1], self.bg_roi)
+            bg_data = load_bg(self.bg_path, self.img_dim[0], self.img_dim[1], self.bg_roi) # TODO: remove ROI for 1.0.0
             self.bg_stokes = self.reconstructor.Stokes_recon(bg_data)
             self.bg_stokes = self.reconstructor.Stokes_transform(self.bg_stokes)
         elif self.config.background_correction == 'local_fit':

--- a/recOrder/plugin/widget/main_widget.py
+++ b/recOrder/plugin/widget/main_widget.py
@@ -2651,7 +2651,7 @@ class MainWidget(QWidget):
             metadata = MetadataReader(metadata_file)
             roi = metadata.ROI
             height, width = roi[2], roi[3]
-            bg_data = load_bg(self.current_bg_path, height, width, roi)
+            bg_data = load_bg(self.current_bg_path, height, width)
         else:
             bg_data = None
 

--- a/recOrder/plugin/widget/main_widget.py
+++ b/recOrder/plugin/widget/main_widget.py
@@ -2651,7 +2651,7 @@ class MainWidget(QWidget):
             metadata = MetadataReader(metadata_file)
             roi = metadata.ROI
             height, width = roi[2], roi[3]
-            bg_data = load_bg(self.current_bg_path, height, width, roi)
+            bg_data = load_bg(self.current_bg_path, height, width, roi) # TODO: remove ROI for 1.0.0
         else:
             bg_data = None
 

--- a/recOrder/plugin/widget/main_widget.py
+++ b/recOrder/plugin/widget/main_widget.py
@@ -2651,7 +2651,7 @@ class MainWidget(QWidget):
             metadata = MetadataReader(metadata_file)
             roi = metadata.ROI
             height, width = roi[2], roi[3]
-            bg_data = load_bg(self.current_bg_path, height, width)
+            bg_data = load_bg(self.current_bg_path, height, width, roi)
         else:
             bg_data = None
 

--- a/recOrder/plugin/workers/acquisition_workers.py
+++ b/recOrder/plugin/workers/acquisition_workers.py
@@ -1224,7 +1224,15 @@ class PolarizationAcquisitionWorker(WorkerBase):
 
         """
 
-        bg_data = load_bg(path, height, width)
+        #TODO: Change to just accept ROI
+        try:
+            metadata_path = get_last_metadata_file(path)
+            metadata = MetadataReader(metadata_path)
+            roi = metadata.ROI
+        except:
+            roi = None
+
+        bg_data = load_bg(path, height, width, roi)
 
         return bg_data
 

--- a/recOrder/plugin/workers/acquisition_workers.py
+++ b/recOrder/plugin/workers/acquisition_workers.py
@@ -1044,7 +1044,7 @@ class PolarizationAcquisitionWorker(WorkerBase):
         if self.calib_window.bg_option in ['global', 'local_fit+']:
             logging.debug('Loading BG Data')
             self._check_abort()
-            bg_data = self._load_bg(self.calib_window.acq_bg_directory, stack.shape[-2], stack.shape[-1])
+            bg_data = load_bg(self.calib_window.acq_bg_directory, stack.shape[-2], stack.shape[-1])
             self._check_abort()
             bg_stokes = recon.Stokes_recon(bg_data)
             self._check_abort()
@@ -1208,25 +1208,6 @@ class PolarizationAcquisitionWorker(WorkerBase):
             current_meta = writer.store.attrs.asdict()
             current_meta['recOrder'] = meta
             writer.store.attrs.put(current_meta)
-
-    def _load_bg(self, path, height, width):
-        """
-        Load background and calibration metadata.
-
-        Parameters
-        ----------
-        path:           (str) path to the BG folder
-        height:         (int) height of BG image
-        width:          (int) widht of BG image
-
-        Returns
-        -------
-
-        """
-
-        bg_data = load_bg(path, height, width)
-
-        return bg_data
 
     def _reconstructor_changed(self):
         """

--- a/recOrder/plugin/workers/acquisition_workers.py
+++ b/recOrder/plugin/workers/acquisition_workers.py
@@ -1044,7 +1044,7 @@ class PolarizationAcquisitionWorker(WorkerBase):
         if self.calib_window.bg_option in ['global', 'local_fit+']:
             logging.debug('Loading BG Data')
             self._check_abort()
-            bg_data = load_bg(self.calib_window.acq_bg_directory, stack.shape[-2], stack.shape[-1])
+            bg_data = self._load_bg(self.calib_window.acq_bg_directory, stack.shape[-2], stack.shape[-1])
             self._check_abort()
             bg_stokes = recon.Stokes_recon(bg_data)
             self._check_abort()
@@ -1208,6 +1208,25 @@ class PolarizationAcquisitionWorker(WorkerBase):
             current_meta = writer.store.attrs.asdict()
             current_meta['recOrder'] = meta
             writer.store.attrs.put(current_meta)
+
+    def _load_bg(self, path, height, width):
+        """
+        Load background and calibration metadata.
+
+        Parameters
+        ----------
+        path:           (str) path to the BG folder
+        height:         (int) height of BG image
+        width:          (int) widht of BG image
+
+        Returns
+        -------
+
+        """
+
+        bg_data = load_bg(path, height, width)
+
+        return bg_data
 
     def _reconstructor_changed(self):
         """

--- a/recOrder/plugin/workers/acquisition_workers.py
+++ b/recOrder/plugin/workers/acquisition_workers.py
@@ -1224,15 +1224,7 @@ class PolarizationAcquisitionWorker(WorkerBase):
 
         """
 
-        #TODO: Change to just accept ROI
-        try:
-            metadata_path = get_last_metadata_file(path)
-            metadata = MetadataReader(metadata_path)
-            roi = metadata.ROI
-        except:
-            roi = None
-
-        bg_data = load_bg(path, height, width, roi)
+        bg_data = load_bg(path, height, width)
 
         return bg_data
 

--- a/recOrder/plugin/workers/acquisition_workers.py
+++ b/recOrder/plugin/workers/acquisition_workers.py
@@ -1211,6 +1211,8 @@ class PolarizationAcquisitionWorker(WorkerBase):
 
     def _load_bg(self, path, height, width):
         """
+        # TODO: remove ROI for 1.0.0
+
         Load background and calibration metadata.
 
         Parameters


### PR DESCRIPTION
When I was testing calibration using an ROI, I noticed that the background correction changed behavior. 

I found that when a calibration ROI was used, the background correction averaged over this ROI then applied that background correction uniformly over the whole image. I cannot think of a reason to average over a FOV within a background image, so I removed this functionality. 

This functionality severely reduces the effectiveness of the "Measured" background corrections when calibrating within an ROI. It's also likely that this bug was partially responsible for Yuming's poor background corrections. 