### PR TITLE
Show RAM warning in GUI / log in CLI

### DIFF
--- a/recOrder/io/utils.py
+++ b/recOrder/io/utils.py
@@ -172,18 +172,33 @@ def get_unimodal_threshold(input_image):
     assert best_threshold > -np.inf, 'Error in unimodal thresholding'
     return best_threshold
 
+
 def ram_message():
+    """
+    Determine if the system's RAM capacity is sufficient for running reconstruction. 
+    The message should be treated as a warning if the RAM detected is less than 32 GB.
+
+    Returns
+    -------
+    ram_report    (is_warning, message)
+    """
     BYTES_PER_GB = 2**30
     gb_available = psutil.virtual_memory().total / BYTES_PER_GB
-    if gb_available < 32:
-        return ' \n'.join(textwrap.wrap(
-               f'\033[91mWARNING:\033[0m recOrder reconstructions often require more than the {gb_available:.1f} ' \
+    is_warning = gb_available < 32
+
+    if is_warning:
+        message = ' \n'.join(textwrap.wrap(
+               f'recOrder reconstructions often require more than the {gb_available:.1f} ' \
                f'GB of RAM that this computer is equipped with. We recommend starting with reconstructions of small ' \
                f'volumes ~1000 x 1000 x 10 and working up to larger volumes while monitoring your RAM usage with '
                f'Task Manager or htop.',
         ))
     else:
-        return f'{gb_available:.1f} GB of RAM is available.'
+        message = f'{gb_available:.1f} GB of RAM is available.'
+    
+    return (is_warning, message)
+
+
 
 def rec_bkg_to_wo_bkg(recorder_option) -> str:
     """

--- a/recOrder/pipelines/pipeline_manager.py
+++ b/recOrder/pipelines/pipeline_manager.py
@@ -3,6 +3,7 @@ from waveorder.io.reader import WaveorderReader, ZarrReader
 from waveorder.io.writer import WaveorderWriter
 import time
 import os
+import logging
 import shutil
 from recOrder.io.utils import MockEmitter, ram_message
 from recOrder.pipelines.qlipp_pipeline import QLIPP
@@ -22,8 +23,8 @@ class PipelineManager:
     """
 
     def __init__(self, config: ConfigReader, overwrite: bool = False, emitter=MockEmitter()):
-        print(ram_message())
-
+        self._check_ram()
+        
         start = time.time()
         print('Reading Data...')
         data = WaveorderReader(config.data_dir, extract_data=True)
@@ -90,6 +91,16 @@ class PipelineManager:
                                                                               pad_z=params['pad_z'],
                                                                               use_gpu=params['use_gpu'],
                                                                               gpu_id=params['gpu_id'])
+
+    def _check_ram(self):
+        """
+        Show a warning if RAM < 32 GB.
+        """
+        is_warning, msg = ram_message()
+        if is_warning:
+            logging.warning(msg)
+        else:
+            logging.info(msg)
 
     def _update_hcs_meta_from_config(self, hcs_meta):
         """

--- a/recOrder/pipelines/pipeline_manager.py
+++ b/recOrder/pipelines/pipeline_manager.py
@@ -5,6 +5,7 @@ import time
 import os
 import logging
 import shutil
+from napari.utils.notifications import show_warning
 from recOrder.io.utils import MockEmitter, ram_message
 from recOrder.pipelines.qlipp_pipeline import QLIPP
 from recOrder.pipelines.phase_from_bf_pipeline import PhaseFromBF
@@ -99,6 +100,7 @@ class PipelineManager:
         is_warning, msg = ram_message()
         if is_warning:
             logging.warning(msg)
+            show_warning(msg)
         else:
             logging.info(msg)
 

--- a/recOrder/plugin/workers/acquisition_workers.py
+++ b/recOrder/plugin/workers/acquisition_workers.py
@@ -10,6 +10,7 @@ from recOrder.io.zarr_converter import ZarrConverter
 from recOrder.io.metadata_reader import MetadataReader, get_last_metadata_file
 from recOrder.io.utils import ram_message, rec_bkg_to_wo_bkg
 from napari.qt.threading import WorkerBaseSignals, WorkerBase
+from napari.utils.notifications import show_warning
 import logging
 from waveorder.io.writer import WaveorderWriter
 import tifffile as tiff
@@ -102,11 +103,21 @@ class BFAcquisitionWorker(WorkerBase):
             self.aborted.emit()
             raise TimeoutError('Stop Requested')
 
+    def _check_ram(self):
+        """
+        Show a warning if RAM < 32 GB.
+        """
+        is_warning, msg = ram_message()
+        if is_warning:
+            show_warning(msg)
+        else:
+            logging.info(msg)
+
     def work(self):
         """
         Function that runs the 2D or 3D acquisition and reconstructs the data
         """
-        logging.info(ram_message())
+        self._check_ram()
         logging.info('Running Acquisition...')
         self._check_abort()
 
@@ -468,11 +479,21 @@ class FluorescenceAcquisitionWorker(WorkerBase):
             self.aborted.emit()
             raise TimeoutError('Stop Requested')
 
+    def _check_ram(self):
+        """
+        Show a warning if RAM < 32 GB.
+        """
+        is_warning, msg = ram_message()
+        if is_warning:
+            show_warning(msg)
+        else:
+            logging.info(msg)
+
     def work(self):
         """
         Function that runs the 2D or 3D acquisition and reconstructs the data
         """
-        logging.info(ram_message())
+        self._check_ram()
         logging.info('Running Acquisition...')
 
         self._check_abort()
@@ -833,11 +854,21 @@ class PolarizationAcquisitionWorker(WorkerBase):
             self.aborted.emit()
             raise TimeoutError('Stop Requested')
 
+    def _check_ram(self):
+        """
+        Show a warning if RAM < 32 GB.
+        """
+        is_warning, msg = ram_message()
+        if is_warning:
+            show_warning(msg)
+        else:
+            logging.info(msg)
+
     def work(self):
         """
         Function that runs the 2D or 3D acquisition and reconstructs the data
         """
-        logging.info(ram_message())
+        self._check_ram()
         logging.info('Running Acquisition...')
 
         # List the Channels to acquire, if 5-state then append 5th channel


### PR DESCRIPTION
The RAM implementation in [#157](https://github.com/mehta-lab/recOrder/pull/157#discussion_r972256905) does not offer a visual hint in the GUI. The use of `print()` in the CLI also limited the way we can format the message. Here is a modified version with a more portable API.