### PR TITLE
Hide "listen" and "overlay" features from `recOrder` GUI

### DIFF
--- a/recOrder/plugin/widget/main_widget.py
+++ b/recOrder/plugin/widget/main_widget.py
@@ -301,6 +301,15 @@ class MainWidget(QWidget):
         self.ui.label_focus_zidx.setHidden(True)
         self.ui.le_focus_zidx.setHidden(True)
 
+        # Hide temporarily unsupported "Listen" functions
+        self.ui.qbutton_listen.setHidden(True)
+        self.ui.chb_pause_updates.setHidden(True)
+
+        # Hide temporarily unsupported "Overlay" functions
+        self.ui.tabWidget.setTabText(self.ui.tabWidget.indexOf(self.ui.Display), "Orientation Legend")
+        self.ui.label_orientation_legend.setHidden(True)
+        self.ui.DisplayOptions.setHidden(True)
+
         # Set initial UI Properties
         self.ui.le_gui_mode.setStyleSheet("border: 1px solid rgb(200,0,0); color: rgb(200,0,0);")
         self.ui.te_log.setStyleSheet('background-color: rgb(32,34,40);')


### PR DESCRIPTION
See screenshots of the changes below:
![Screenshot 2022-09-16 113632](https://user-images.githubusercontent.com/9554101/190709736-9e6b0c89-3b10-4a1d-8866-9bf61bb4f645.png)

![image](https://user-images.githubusercontent.com/9554101/190708005-39fda1ae-9524-4dc3-9ac0-83326032da92.png)

This PR is consistent with our goal for 0.2.0 --- all user-facing features should work well. I'm hiding these features because they are not currently working well, and we're planning to fix/improve them for 1.0.0.

