### PR TITLE
`Capture Background` without calibration yields a warning

### DIFF
--- a/recOrder/plugin/widget/main_widget.py
+++ b/recOrder/plugin/widget/main_widget.py
@@ -1,5 +1,3 @@
-from multiprocessing.sharedctypes import Value
-from tkinter.messagebox import showerror
 from recOrder.calib.Calibration import QLIPP_Calibration, LC_DEVICE_NAME
 from pycromanager import Bridge
 from qtpy.QtCore import Slot, Signal, Qt

--- a/recOrder/plugin/widget/main_widget.py
+++ b/recOrder/plugin/widget/main_widget.py
@@ -301,6 +301,15 @@ class MainWidget(QWidget):
         self.ui.label_focus_zidx.setHidden(True)
         self.ui.le_focus_zidx.setHidden(True)
 
+        # Hide temporarily unsupported "Listen" functions
+        self.ui.qbutton_listen.setHidden(True)
+        self.ui.chb_pause_updates.setHidden(True)
+
+        # Hide temporarily unsupported "Overlay" functions
+        self.ui.tabWidget.setTabText(self.ui.tabWidget.indexOf(self.ui.Display), "Orientation Legend")
+        self.ui.label_orientation_legend.setHidden(True)
+        self.ui.DisplayOptions.setHidden(True)
+
         # Set initial UI Properties
         self.ui.le_gui_mode.setStyleSheet("border: 1px solid rgb(200,0,0); color: rgb(200,0,0);")
         self.ui.te_log.setStyleSheet('background-color: rgb(32,34,40);')

--- a/recOrder/plugin/widget/main_widget.py
+++ b/recOrder/plugin/widget/main_widget.py
@@ -1,3 +1,5 @@
+from multiprocessing.sharedctypes import Value
+from tkinter.messagebox import showerror
 from recOrder.calib.Calibration import QLIPP_Calibration, LC_DEVICE_NAME
 from pycromanager import Bridge
 from qtpy.QtCore import Slot, Signal, Qt
@@ -18,6 +20,7 @@ from recOrder.io.config_reader import ConfigReader, PROCESSING, PREPROCESSING, P
 from waveorder.io.reader import WaveorderReader
 from pathlib import Path, PurePath
 from napari import Viewer
+from napari.utils.notifications import show_warning
 from numpydoc.docscrape import NumpyDocString
 from packaging import version
 import numpy as np
@@ -2535,6 +2538,12 @@ class MainWidget(QWidget):
         -------
 
         """
+
+        if self.calib is None:
+            no_calibration_message = """Capturing a background requires calibrated liquid crystals. \
+                Please either run a calibration or load a calibration from file."""
+            show_warning(no_calibration_message)
+            return
 
         # Init worker and thread
         self.worker = BackgroundCaptureWorker(self, self.calib)

--- a/recOrder/plugin/widget/main_widget.py
+++ b/recOrder/plugin/widget/main_widget.py
@@ -304,15 +304,6 @@ class MainWidget(QWidget):
         self.ui.label_focus_zidx.setHidden(True)
         self.ui.le_focus_zidx.setHidden(True)
 
-        # Hide temporarily unsupported "Listen" functions
-        self.ui.qbutton_listen.setHidden(True)
-        self.ui.chb_pause_updates.setHidden(True)
-
-        # Hide temporarily unsupported "Overlay" functions
-        self.ui.tabWidget.setTabText(self.ui.tabWidget.indexOf(self.ui.Display), "Orientation Legend")
-        self.ui.label_orientation_legend.setHidden(True)
-        self.ui.DisplayOptions.setHidden(True)
-
         # Set initial UI Properties
         self.ui.le_gui_mode.setStyleSheet("border: 1px solid rgb(200,0,0); color: rgb(200,0,0);")
         self.ui.te_log.setStyleSheet('background-color: rgb(32,34,40);')

--- a/recOrder/plugin/widget/main_widget.py
+++ b/recOrder/plugin/widget/main_widget.py
@@ -18,7 +18,6 @@ from recOrder.io.config_reader import ConfigReader, PROCESSING, PREPROCESSING, P
 from waveorder.io.reader import WaveorderReader
 from pathlib import Path, PurePath
 from napari import Viewer
-from napari.utils.notifications import show_warning
 from numpydoc.docscrape import NumpyDocString
 from packaging import version
 import numpy as np
@@ -2531,9 +2530,8 @@ class MainWidget(QWidget):
         if self.calib is None:
             no_calibration_message = """Capturing a background requires calibrated liquid crystals. \
                 Please either run a calibration or load a calibration from file."""
-            show_warning(no_calibration_message)
-            return
-
+            raise RuntimeError(no_calibration_message)
+            
         # Init worker and thread
         self.worker = BackgroundCaptureWorker(self, self.calib)
 


### PR DESCRIPTION
Currently, clicking `Capture Background` before loading or running a calibration gives the following error:
`Error: 'NoneType' object has no attribute 'capture_bg'`

This PR changes `recOrder`'s behavior so that the following warning is shown instead: 

```Capturing a background requires calibrated liquid crystals. Please either run a calibration or load a calibration from file.```

(Please excuse the extra commits---I'm still getting the hang of VScode :) ) 