### PR TITLE
Mismatched x/y size of background and acquisition should error instead of warn

### DIFF
--- a/recOrder/io/utils.py
+++ b/recOrder/io/utils.py
@@ -86,15 +86,12 @@ def load_bg(bg_path, height, width, ROI=None):
         bg_img_list.append(tiff.imread(bg_path))
     bg_img_arr = np.array(bg_img_list) # CYX
 
-    # Warn if shapes do not match
+    # Error if shapes do not match
     # TODO: 1.0.0 move these validation check to waveorder's Polscope_bg_correction
     if bg_img_arr.shape[1:] != (height, width):
-        warning_msg = """
-        The background image has a different X/Y size than the acquired image. 
-        You can expect a downstream error or an incorrect background correction.  
-        """
-        logging.warning(warning_msg)
-
+        error_msg = "The background image has a different X/Y size than the acquired image."
+        raise ValueError(error_msg)
+        
     return bg_img_arr # CYX
 
 


### PR DESCRIPTION
This PR is an improvement on #181 given a discussion @ziw-liu and I had about errors vs. warnings. 

Since `recOrder` can't recover from mismatched background and acquisition sizes, I have changed this warning to an error. This has the added benefit of making the error message appear to the user directly, instead of the old behavior where we received a downstream numpy error and a less visible warning. 