### PR TITLE
Initialize calibration values when loading from metadata files

### DIFF
--- a/recOrder/plugin/workers/calibration_workers.py
+++ b/recOrder/plugin/workers/calibration_workers.py
@@ -373,7 +373,7 @@ def load_calibration(calib, metadata: MetadataReader):
                 # set the swing value attribute (e.g. 'swing0')
                 if state != "ext":
                     swing_name = "swing" + state
-                    setattr(calib, swing_name, metadata.Swing_measured[i + 1])
+                    setattr(calib, swing_name, metadata.Swing_measured[i - 1])
 
     _set_calib_attrs(calib, metadata)
 

--- a/recOrder/plugin/workers/calibration_workers.py
+++ b/recOrder/plugin/workers/calibration_workers.py
@@ -355,7 +355,7 @@ def load_calibration(calib, metadata: MetadataReader):
     """
     calib.calib_scheme = metadata.Calibration_scheme
 
-    def _set_calib_retardance(calib):
+    def _set_calib_attrs(calib, metadata):
         """Set the retardance attributes in the recOrder Calibration object"""
         if calib.calib_scheme == "4-State":
             lc_states = ['ext', '0', '60', '120']
@@ -367,9 +367,14 @@ def load_calibration(calib, metadata: MetadataReader):
             retardance_values = metadata.__getattribute__("LC" + side + "_retardance")
             for i, state in enumerate(lc_states):
                 # set the retardance value attribute (e.g. 'lca_0')
-                setattr(calib, "lc" + side.lower() + state, retardance_values[i])
+                retardance_name = "lc" + side.lower() + "_" + state
+                setattr(calib, retardance_name, retardance_values[i])
+                # set the swing value attribute (e.g. 'swing0')
+                if state != "ext":
+                    swing_name = "swing" + state
+                    setattr(calib, swing_name, metadata.__getattribute__("Swing_" + state))
 
-    _set_calib_retardance(calib)
+    _set_calib_attrs(calib, metadata)
 
     for state, lca, lcb in zip([f'State{i}' for i in range(5)], metadata.LCA_retardance, metadata.LCB_retardance):
         calib.define_lc_state(state, lca, lcb)

--- a/recOrder/plugin/workers/calibration_workers.py
+++ b/recOrder/plugin/workers/calibration_workers.py
@@ -1,4 +1,3 @@
-from argparse import MetavarTypeHelpFormatter
 from qtpy.QtCore import Signal
 from napari.qt.threading import WorkerBaseSignals, WorkerBase, thread_worker
 from recOrder.compute.qlipp_compute import initialize_reconstructor, \

--- a/recOrder/plugin/workers/calibration_workers.py
+++ b/recOrder/plugin/workers/calibration_workers.py
@@ -353,6 +353,23 @@ def load_calibration(calib, metadata: MetadataReader):
     -------
     calib           (object) updated recOrder Calibration Class
     """
+    calib.calib_scheme = metadata.Calibration_scheme
+
+    def _set_calib_retardance(calib):
+        """Set the retardance attributes in the recOrder Calibration object"""
+        if calib.calib_scheme == "4-State":
+            lc_states = ['ext', '0', '60', '120']
+        elif calib.calib_scheme == "5-State":
+            lc_states = ['ext', '0', '45', '90', '135']
+        else:
+            raise ValueError("Invalid calibration scheme in metadata: {calib.calib_scheme}")
+        for side in ("A", "B"):
+            retardance_values = metadata.__getattribute__("LC" + side + "_retardance")
+            for i, state in enumerate(lc_states):
+                # set the retardance value attribute (e.g. 'lca_0')
+                setattr(calib, "lc" + side.lower() + state, retardance_values[i])
+
+    _set_calib_retardance(calib)
 
     for state, lca, lcb in zip([f'State{i}' for i in range(5)], metadata.LCA_retardance, metadata.LCB_retardance):
         calib.define_lc_state(state, lca, lcb)

--- a/recOrder/plugin/workers/calibration_workers.py
+++ b/recOrder/plugin/workers/calibration_workers.py
@@ -1,3 +1,4 @@
+from argparse import MetavarTypeHelpFormatter
 from qtpy.QtCore import Signal
 from napari.qt.threading import WorkerBaseSignals, WorkerBase, thread_worker
 from recOrder.compute.qlipp_compute import initialize_reconstructor, \
@@ -372,7 +373,7 @@ def load_calibration(calib, metadata: MetadataReader):
                 # set the swing value attribute (e.g. 'swing0')
                 if state != "ext":
                     swing_name = "swing" + state
-                    setattr(calib, swing_name, metadata.__getattribute__("Swing_" + state))
+                    setattr(calib, swing_name, metadata.Swing_measured[i + 1])
 
     _set_calib_attrs(calib, metadata)
 


### PR DESCRIPTION
Previously loading calibration from a metadata file does not initialize LC values in the `QLIPP_Calibration` object created by the `load_calibration` thread worker, which [causes an error when trying to capture background afterwards](https://github.com/mehta-lab/recOrder/issues/180). This PR addresses the error by setting the required values, although the necessity of fully initializing the `QLIPP_Calibration` object when loading from metadata files is still up to debate.