### PR TITLE
Plot calibrated LC states

### DIFF
--- a/recOrder/calib/Calibration.py
+++ b/recOrder/calib/Calibration.py
@@ -921,7 +921,7 @@ class QLIPP_Calibration():
             "axes.spines.top": False,
         }):
             fig = plt.figure("Calibrated LC States")
-            plt.scatter(lc_values["LCA"], lc_values["LCB"], 'r')
+            plt.scatter(lc_values["LCA"], lc_values["LCB"], c='r')
             plt.axis("equal")
             plt.xlabel("LCA retardance")
             plt.ylabel("LCB retardance")

--- a/recOrder/calib/Calibration.py
+++ b/recOrder/calib/Calibration.py
@@ -919,7 +919,7 @@ class QLIPP_Calibration():
         with plt.rc_context({
             "axes.spines.right": False,
             "axes.spines.top": False,
-            "axis.axis": "equal",
+            "axes.axis": "equal",
         }):
             fig = plt.figure("Calibrated LC States")
             plt.scatter(lc_values["LCA"], lc_values["LCB"], 'ro')

--- a/recOrder/calib/Calibration.py
+++ b/recOrder/calib/Calibration.py
@@ -911,7 +911,7 @@ class QLIPP_Calibration():
         lc_sides = ("A", "B")
         lc_values = {
             "LC{lc_side}": [
-                self.__getattribute__("lc" + lc_side + pol) 
+                self.__getattribute__("lc" + lc_side.lower() + "_" + pol) 
                 for pol in self._pol_states
             ]
             for lc_side in lc_sides

--- a/recOrder/calib/Calibration.py
+++ b/recOrder/calib/Calibration.py
@@ -919,10 +919,10 @@ class QLIPP_Calibration():
         with plt.rc_context({
             "axes.spines.right": False,
             "axes.spines.top": False,
-            "axes.axis": "equal",
         }):
             fig = plt.figure("Calibrated LC States")
             plt.scatter(lc_values["LCA"], lc_values["LCB"], 'ro')
+            plt.axis("equal")
             plt.xlabel("LCA retardance")
             plt.ylabel("LCB retardance")
             for pol in self._pol_states:

--- a/recOrder/calib/Calibration.py
+++ b/recOrder/calib/Calibration.py
@@ -874,6 +874,64 @@ class QLIPP_Calibration():
                         break
         plt.show()
 
+    @property
+    def _pol_states(self):
+        """The polarization states of this calibration.
+
+        Returns
+        -------
+        tuple
+            Names of all the polarization states.
+
+        Raises
+        ------
+        ValueError
+            Found illegal calibration state.
+        """
+        if self.calib_scheme == "4-State":
+            pols = ("ext", "0", "60", "120")
+        elif self.calib_scheme == "4-State":
+            pols = ("ext", "0", "45", "90", "135")
+        else:
+            raise ValueError("Invalid calibration state: {self.calib_scheme}.")
+        return pols
+
+    def plot_lc_states(self, annot_offset: float = 0.004):
+        """Generate a Matplotlib figure with a scatter plot of the calibrated LC states.
+
+        Parameters
+        ----------
+        annot_offset : float, optional
+            The offset of annotation text from data points, by default 0.004
+
+        Returns
+        -------
+        fig : matplotlib.figure.Figure
+        """
+        lc_sides = ("A", "B")
+        lc_values = {
+            "LC{lc_side}": [
+                self.__getattribute__("lc" + lc_side + pol) 
+                for pol in self._pol_states
+            ]
+            for lc_side in lc_sides
+        }
+        with plt.rc_context({
+            "axes.spines.right": False,
+            "axes.spines.top": False,
+            "axis.axis": "equal",
+        }):
+            fig = plt.figure("Calibrated LC States")
+            plt.scatter(lc_values["LCA"], lc_values["LCB"], 'ro')
+            plt.xlabel("LCA retardance")
+            plt.ylabel("LCB retardance")
+            for pol in self._pol_states:
+                plt.annotate(
+                    pol, 
+                    (lc_sides["LCA"] + annot_offset, lc_values["LCB"] + annot_offset)
+            )
+            return fig
+
 
     def capture_bg(self, n_avg, directory):
         """"

--- a/recOrder/calib/Calibration.py
+++ b/recOrder/calib/Calibration.py
@@ -921,7 +921,7 @@ class QLIPP_Calibration():
             "axes.spines.top": False,
         }):
             fig = plt.figure("Calibrated LC States")
-            plt.scatter(lc_values["LCA"], lc_values["LCB"], 'ro')
+            plt.scatter(lc_values["LCA"], lc_values["LCB"], 'r')
             plt.axis("equal")
             plt.xlabel("LCA retardance")
             plt.ylabel("LCB retardance")

--- a/recOrder/calib/Calibration.py
+++ b/recOrder/calib/Calibration.py
@@ -893,7 +893,7 @@ class QLIPP_Calibration():
         elif self.calib_scheme == "4-State":
             pols = ("ext", "0", "45", "90", "135")
         else:
-            raise ValueError("Invalid calibration state: {self.calib_scheme}.")
+            raise ValueError(f"Invalid calibration state: {self.calib_scheme}.")
         return pols
 
     def plot_lc_states(self, annot_offset: float = 0.004):
@@ -910,7 +910,7 @@ class QLIPP_Calibration():
         """
         lc_sides = ["A", "B"]
         lc_values = {
-            "LC{lc_side}": [
+            f"LC{lc_side}": [
                 self.__getattribute__("lc" + lc_side.lower() + "_" + pol) 
                 for pol in self._pol_states
             ]

--- a/recOrder/calib/Calibration.py
+++ b/recOrder/calib/Calibration.py
@@ -925,10 +925,10 @@ class QLIPP_Calibration():
             plt.axis("equal")
             plt.xlabel("LCA retardance")
             plt.ylabel("LCB retardance")
-            for pol in self._pol_states:
+            for i, pol in enumerate(self._pol_states):
                 plt.annotate(
                     pol, 
-                    (lc_values["LCA"] + annot_offset, lc_values["LCB"] + annot_offset)
+                    (lc_values["LCA"][i] + annot_offset, lc_values["LCB"][i] + annot_offset)
             )
             return fig
 

--- a/recOrder/calib/Calibration.py
+++ b/recOrder/calib/Calibration.py
@@ -908,7 +908,7 @@ class QLIPP_Calibration():
         -------
         fig : matplotlib.figure.Figure
         """
-        lc_sides = ("A", "B")
+        lc_sides = ["A", "B"]
         lc_values = {
             "LC{lc_side}": [
                 self.__getattribute__("lc" + lc_side.lower() + "_" + pol) 

--- a/recOrder/calib/Calibration.py
+++ b/recOrder/calib/Calibration.py
@@ -890,7 +890,7 @@ class QLIPP_Calibration():
         """
         if self.calib_scheme == "4-State":
             pols = ("ext", "0", "60", "120")
-        elif self.calib_scheme == "4-State":
+        elif self.calib_scheme == "5-State":
             pols = ("ext", "0", "45", "90", "135")
         else:
             raise ValueError(f"Invalid calibration state: {self.calib_scheme}.")

--- a/recOrder/calib/Calibration.py
+++ b/recOrder/calib/Calibration.py
@@ -875,7 +875,7 @@ class QLIPP_Calibration():
         plt.show()
 
     @property
-    def _pol_states(self):
+    def pol_states(self):
         """The polarization states of this calibration.
 
         Returns
@@ -896,42 +896,23 @@ class QLIPP_Calibration():
             raise ValueError(f"Invalid calibration state: {self.calib_scheme}.")
         return pols
 
-    def plot_lc_states(self, annot_offset: float = 0.004):
-        """Generate a Matplotlib figure with a scatter plot of the calibrated LC states.
-
-        Parameters
-        ----------
-        annot_offset : float, optional
-            The offset of annotation text from data points, by default 0.004
+    @property
+    def lc_states(self):
+        """The optimized LC retardance values of this calibration.
 
         Returns
         -------
-        fig : matplotlib.figure.Figure
+        dict
+            `Dict{"LCA": List[ext, ...], "LCB": List[ext, ...]}`
         """
         lc_sides = ["A", "B"]
-        lc_values = {
+        return {
             f"LC{lc_side}": [
                 self.__getattribute__("lc" + lc_side.lower() + "_" + pol) 
-                for pol in self._pol_states
+                for pol in self.pol_states
             ]
             for lc_side in lc_sides
         }
-        with plt.rc_context({
-            "axes.spines.right": False,
-            "axes.spines.top": False,
-        }):
-            fig = plt.figure("Calibrated LC States")
-            plt.scatter(lc_values["LCA"], lc_values["LCB"], c='r')
-            plt.axis("equal")
-            plt.xlabel("LCA retardance")
-            plt.ylabel("LCB retardance")
-            for i, pol in enumerate(self._pol_states):
-                plt.annotate(
-                    pol, 
-                    (lc_values["LCA"][i] + annot_offset, lc_values["LCB"][i] + annot_offset)
-            )
-            return fig
-
 
     def capture_bg(self, n_avg, directory):
         """"

--- a/recOrder/calib/Calibration.py
+++ b/recOrder/calib/Calibration.py
@@ -928,7 +928,7 @@ class QLIPP_Calibration():
             for pol in self._pol_states:
                 plt.annotate(
                     pol, 
-                    (lc_sides["LCA"] + annot_offset, lc_values["LCB"] + annot_offset)
+                    (lc_values["LCA"] + annot_offset, lc_values["LCB"] + annot_offset)
             )
             return fig
 

--- a/recOrder/plugin/widget/main_widget.py
+++ b/recOrder/plugin/widget/main_widget.py
@@ -1730,6 +1730,11 @@ class MainWidget(QWidget):
         pol_states, lc_values = value
         annot_offset = 0.004 # offset annotation text from data points
 
+        # Calculate circle 
+        theta = np.linspace(0, 2*np.pi, 100)
+        x_circ = self.swing*np.cos(theta) + lc_values["LCA"][0]
+        y_circ = self.swing*np.sin(theta) + lc_values["LCB"][0]
+
         import matplotlib.pyplot as plt
         with plt.rc_context({
             "axes.spines.right": False,
@@ -1737,6 +1742,7 @@ class MainWidget(QWidget):
         }) and plt.ion():
             plt.figure("Calibrated LC States")
             plt.scatter(lc_values["LCA"], lc_values["LCB"], c='r')
+            plt.plot(x_circ, y_circ, 'k--', alpha=0.25)
             plt.axis("equal")
             plt.xlabel("LCA retardance")
             plt.ylabel("LCB retardance")

--- a/recOrder/plugin/widget/main_widget.py
+++ b/recOrder/plugin/widget/main_widget.py
@@ -1719,8 +1719,33 @@ class MainWidget(QWidget):
             pass
 
     @Slot(object)
-    def handle_plot_lc_states_emit(self, value):
-        value.show()
+    def handle_lc_states_emit(self, value: tuple[tuple, dict[str, list]]):
+        """Receive and plot polarization state and calibrated LC retardance values from the calibration worker.
+
+        Parameters
+        ----------
+        value : tuple[tuple, dict[str, list]]
+            2-tuple consisting of a tuple of polarization state names and a dictionary of LC retardance values.
+        """
+        pol_states, lc_values = value
+        annot_offset = 0.004 # offset annotation text from data points
+
+        import matplotlib.pyplot as plt
+        with plt.rc_context({
+            "axes.spines.right": False,
+            "axes.spines.top": False,
+        }):
+            plt.figure("Calibrated LC States")
+            plt.scatter(lc_values["LCA"], lc_values["LCB"], c='r')
+            plt.axis("equal")
+            plt.xlabel("LCA retardance")
+            plt.ylabel("LCB retardance")
+            for i, pol in enumerate(pol_states):
+                plt.annotate(
+                    pol, 
+                    (lc_values["LCA"][i] + annot_offset, lc_values["LCB"][i] + annot_offset)
+            )
+            plt.show()
 
     @Slot(object)
     def handle_bg_image_update(self, value):
@@ -2545,7 +2570,7 @@ class MainWidget(QWidget):
         self.worker.calib_assessment_msg.connect(self.handle_calibration_assessment_msg_update)
         self.worker.calib_file_emit.connect(self.handle_calib_file_update)
         self.worker.plot_sequence_emit.connect(self.handle_plot_sequence_update)
-        self.worker.plot_lc_states_emit.connect(self.handle_plot_lc_states_emit)
+        self.worker.lc_states.connect(self.handle_lc_states_emit)
         self.worker.started.connect(self._disable_buttons)
         self.worker.finished.connect(self._enable_buttons)
         self.worker.errored.connect(self._handle_error)

--- a/recOrder/plugin/widget/main_widget.py
+++ b/recOrder/plugin/widget/main_widget.py
@@ -1719,6 +1719,10 @@ class MainWidget(QWidget):
             pass
 
     @Slot(object)
+    def handle_plot_lc_states_emit(self, value):
+        value.show()
+
+    @Slot(object)
     def handle_bg_image_update(self, value):
 
         if 'Background Images' in self.viewer.layers:
@@ -2541,6 +2545,7 @@ class MainWidget(QWidget):
         self.worker.calib_assessment_msg.connect(self.handle_calibration_assessment_msg_update)
         self.worker.calib_file_emit.connect(self.handle_calib_file_update)
         self.worker.plot_sequence_emit.connect(self.handle_plot_sequence_update)
+        self.worker.plot_lc_states_emit.connect(self.handle_plot_lc_states_emit)
         self.worker.started.connect(self._disable_buttons)
         self.worker.finished.connect(self._enable_buttons)
         self.worker.errored.connect(self._handle_error)

--- a/recOrder/plugin/widget/main_widget.py
+++ b/recOrder/plugin/widget/main_widget.py
@@ -1735,6 +1735,7 @@ class MainWidget(QWidget):
         y_circ = self.swing*np.sin(theta) + lc_values["LCB"][0]
 
         import matplotlib.pyplot as plt
+        plt.close('all')
         with plt.rc_context({
             "axes.spines.right": False,
             "axes.spines.top": False,

--- a/recOrder/plugin/widget/main_widget.py
+++ b/recOrder/plugin/widget/main_widget.py
@@ -1734,7 +1734,7 @@ class MainWidget(QWidget):
         with plt.rc_context({
             "axes.spines.right": False,
             "axes.spines.top": False,
-        }):
+        }) and plt.ion():
             plt.figure("Calibrated LC States")
             plt.scatter(lc_values["LCA"], lc_values["LCB"], c='r')
             plt.axis("equal")
@@ -1745,7 +1745,6 @@ class MainWidget(QWidget):
                     pol, 
                     (lc_values["LCA"][i] + annot_offset, lc_values["LCB"][i] + annot_offset)
             )
-            plt.show()
 
     @Slot(object)
     def handle_bg_image_update(self, value):

--- a/recOrder/plugin/widget/main_widget.py
+++ b/recOrder/plugin/widget/main_widget.py
@@ -1728,8 +1728,7 @@ class MainWidget(QWidget):
             2-tuple consisting of a tuple of polarization state names and a dictionary of LC retardance values.
         """
         pol_states, lc_values = value
-        annot_offset = 0.004 # offset annotation text from data points
-
+    
         # Calculate circle 
         theta = np.linspace(0, 2*np.pi, 100)
         x_circ = self.swing*np.cos(theta) + lc_values["LCA"][0]
@@ -1749,7 +1748,10 @@ class MainWidget(QWidget):
             for i, pol in enumerate(pol_states):
                 plt.annotate(
                     pol, 
-                    (lc_values["LCA"][i] + annot_offset, lc_values["LCB"][i] + annot_offset)
+                    xy=(lc_values["LCA"][i], lc_values["LCB"][i]),
+                    xycoords='data',
+                    xytext=(10,10), # annotation offset
+                    textcoords='offset points'
             )
 
     @Slot(object)

--- a/recOrder/plugin/widget/main_widget.py
+++ b/recOrder/plugin/widget/main_widget.py
@@ -1718,7 +1718,7 @@ class MainWidget(QWidget):
         else:
             pass
 
-    @Slot(object)
+    @Slot(tuple)
     def handle_lc_states_emit(self, value: tuple[tuple, dict[str, list]]):
         """Receive and plot polarization state and calibrated LC retardance values from the calibration worker.
 

--- a/recOrder/plugin/workers/calibration_workers.py
+++ b/recOrder/plugin/workers/calibration_workers.py
@@ -35,7 +35,7 @@ class CalibrationSignals(WorkerBaseSignals):
     calib_assessment_msg = Signal(str)
     calib_file_emit = Signal(str)
     plot_sequence_emit = Signal(str)
-    plot_lc_states_emit = Signal(object)
+    lc_states = Signal(tuple)
     aborted = Signal()
 
 
@@ -207,8 +207,8 @@ class CalibrationWorker(CalibrationWorkerBase, signals=CalibrationSignals):
 
         self._check_abort()
 
-        # Plot calibrated LC states
-        self._plot_lc_states()
+        # Emit calibrated LC states for plotting
+        self.lc_states.emit((self.calib.pol_states, self.calib.lc_states))
 
         logging.info("\n=======Finished Calibration=======\n")
         logging.info(f"EXTINCTION = {extinction_ratio:.2f}")
@@ -280,11 +280,6 @@ class CalibrationWorker(CalibrationWorkerBase, signals=CalibrationSignals):
         self.calib.opt_I135(0.05, 0.05)
         self.progress_update.emit((85, 'Writing Metadata...'))
 
-        self._check_abort()
-
-    def _plot_lc_states(self):
-        """Emit a Matplotlib scatter plot figure of the calibrated LC states."""
-        self.plot_lc_states_emit.emit(self.calib.plot_lc_states(annot_offset=0.004))
         self._check_abort()
 
     def _assess_calibration(self):

--- a/recOrder/plugin/workers/calibration_workers.py
+++ b/recOrder/plugin/workers/calibration_workers.py
@@ -35,6 +35,7 @@ class CalibrationSignals(WorkerBaseSignals):
     calib_assessment_msg = Signal(str)
     calib_file_emit = Signal(str)
     plot_sequence_emit = Signal(str)
+    plot_lc_states_emit = Signal(object)
     aborted = Signal()
 
 
@@ -206,6 +207,9 @@ class CalibrationWorker(CalibrationWorkerBase, signals=CalibrationSignals):
 
         self._check_abort()
 
+        # Plot calibrated LC states
+        self._plot_lc_states()
+
         logging.info("\n=======Finished Calibration=======\n")
         logging.info(f"EXTINCTION = {extinction_ratio:.2f}")
         logging.debug("\n=======Finished Calibration=======\n")
@@ -276,6 +280,11 @@ class CalibrationWorker(CalibrationWorkerBase, signals=CalibrationSignals):
         self.calib.opt_I135(0.05, 0.05)
         self.progress_update.emit((85, 'Writing Metadata...'))
 
+        self._check_abort()
+
+    def _plot_lc_states(self):
+        """Emit a Matplotlib scatter plot figure of the calibrated LC states."""
+        self.plot_lc_states_emit.emit(self.calib.plot_lc_states(annot_offset=0.004))
         self._check_abort()
 
     def _assess_calibration(self):


### PR DESCRIPTION
As mehta-lab/waveorder#323 suggests, plotting the calibrated LC states can be useful for debugging mehta-lab/waveorder#324 and validating calibration in general. This PR approaches the feature request in a minimal and contained way without tampering with any existing UI component.

**Expected behavior**
A pop-up window appears upon the finishing of a calibration job:
![win_10_plot_demo](https://user-images.githubusercontent.com/67518483/192834539-07e7ba6a-d6ae-4764-b196-5d1bf0f2f4ef.png)

**Concerns**
A pop-up window is not the most elegant design and is against the `napari` philosophy.