### PR TITLE
Hide "Use Cropped ROI" checkbox

### DIFF
--- a/recOrder/plugin/widget/main_widget.py
+++ b/recOrder/plugin/widget/main_widget.py
@@ -310,6 +310,9 @@ class MainWidget(QWidget):
         self.ui.label_orientation_legend.setHidden(True)
         self.ui.DisplayOptions.setHidden(True)
 
+        # Hide "Use Cropped ROI "
+        self.ui.chb_use_roi.setHidden(True)
+
         # Set initial UI Properties
         self.ui.le_gui_mode.setStyleSheet("border: 1px solid rgb(200,0,0); color: rgb(200,0,0);")
         self.ui.te_log.setStyleSheet('background-color: rgb(32,34,40);')


### PR DESCRIPTION
@ieivanov's suggested this change since the "Use Cropped ROI" checkbox mostly recreates the behavior of micromanager ROI functions. 