### PR TITLE
Fix bug in calibration_metadata writer

### DIFF
--- a/recOrder/calib/Calibration.py
+++ b/recOrder/calib/Calibration.py
@@ -987,8 +987,8 @@ class CalibrationData:
         self.calib_wavelengths = np.array([i[:3] for i in header[1::3]]).astype('double')
 
         self.wavelength = None
-        self.V_min = 0
-        self.V_max = 20
+        self.V_min = 0.0
+        self.V_max = 20.0
 
         if interp_method in ['linear', 'schnoor_fit']:
             self.interp_method = interp_method


### PR DESCRIPTION
Changing `V_min` and `V_max` to `float` as  `QLIPP_Calibration.write_metadata` fails to write json metadata if integer voltage is passed.