### PR TITLE
Recommend MM 2022-09-20

### DIFF
--- a/docs/microscope-installation-guide.md
+++ b/docs/microscope-installation-guide.md
@@ -27,9 +27,9 @@ should launch napari (may take 15 seconds on a fresh installation) with the recO
  
 ## Install and configure `Micromanager`
 
-Install `Micromanager 2.0` nightly build `20220901` (https://micro-manager.org/Micro-Manager_Nightly_Builds). 
+Install `Micromanager 2.0` nightly build `20220920` (https://micro-manager.org/Micro-Manager_Nightly_Builds). 
 
-**Note:** We have tested recOrder with `20220901`, but most features will work with newer builds. We recommend testing a minimal installation with `20220901` before testing with a different nightly build or additional device drivers. 
+**Note:** We have tested recOrder with `20220920`, but most features will work with newer builds. We recommend testing a minimal installation with `20220920` before testing with a different nightly build or additional device drivers. 
 
 Before launching `Micromanager`, download the Meadowlark device adapters and calibration files from the [release page](https://github.com/mehta-lab/recOrder/releases/) and place these three unzipped files into your `Micromanager` folder (likely `C:\Program Files\Micro-Manager` or similar). 
 

--- a/recOrder/plugin/widget/main_widget.py
+++ b/recOrder/plugin/widget/main_widget.py
@@ -1270,7 +1270,7 @@ class MainWidget(QWidget):
         -------
 
         """
-        RECOMMENDED_MM = '20220901'
+        RECOMMENDED_MM = '20220920'
         ZMQ_TARGET_VERSION = '4.2.0'
         try:
             # Try to open Bridge. Requires micromanager to be open with server running.


### PR DESCRIPTION
In #141 @ieivanov requested an slightly newer version of MM so that a [recent change to a device driver was included](https://github.com/micro-manager/mmCoreAndDevices/pull/238).
I tested `recOrder` with 2022-09-20 and all acquisition functionality is working. `pycromanager` did not require an upgrade. 

This PR updates the docs and warning messages only.