### PR TITLE
Fix 'Load Default Config' in offline mode

### DIFF
--- a/recOrder/plugin/config_offline_default.yml
+++ b/recOrder/plugin/config_offline_default.yml
@@ -1,0 +1,43 @@
+dataset:
+  background: ''
+  background_ROI: null
+  calibration_metadata: ''
+  data_dir: ''
+  data_save_name: ''
+  data_type: zarr
+  method: QLIPP
+  mode: 3D
+  positions:
+  - all
+  save_dir: ''
+  timepoints:
+  - all
+processing:
+  NA_condenser: 0.5
+  NA_objective: 1.3
+  TV_reg_abs_2D: 0.0001
+  TV_reg_ph_2D: 0.0001
+  TV_reg_ph_3D: 5.0e-05
+  Tik_reg_abs_2D: 0.0001
+  Tik_reg_ph_2D: 0.0001
+  Tik_reg_ph_3D: 0.0001
+  background_correction: None
+  brightfield_channel_index: 0
+  focus_zidx: null
+  gpu_id: 0
+  itr_2D: 50
+  itr_3D: 50
+  magnification: 60.0
+  n_objective_media: 1.3
+  output_channels:
+  - ''
+  pad_z: 0
+  phase_denoiser_2D: Tikhonov
+  phase_denoiser_3D: Tikhonov
+  pixel_size: 6.9
+  qlipp_birefringence_only: false
+  reg: 0.0001
+  rho_2D: 1
+  rho_3D: 0.001
+  use_gpu: false
+  wavelength: 532

--- a/recOrder/plugin/widget/main_widget.py
+++ b/recOrder/plugin/widget/main_widget.py
@@ -283,7 +283,7 @@ class MainWidget(QWidget):
         self.ui.label_logo.setPixmap(logo_pixmap)
 
         # Get default config file
-        self.default_config_file = os.path.join(recorder_dir, "recOrder/plugin/config_offline_default.yml")
+        self.default_offline_config = os.path.join(recorder_dir, "recOrder/plugin/config_offline_default.yml")
 
         # Hide initial UI elements for later implementation or for later pop-up purposes
         self.ui.label_lca.hide()
@@ -2490,7 +2490,8 @@ class MainWidget(QWidget):
 
     @Slot(bool)
     def load_default_config(self):
-        self.load_config(self.default_config_file)
+        self.config_reader = ConfigReader(self.default_offline_config)
+        self._populate_from_config()
 
     @Slot(int)
     def update_sat_scale(self):

--- a/recOrder/plugin/widget/main_widget.py
+++ b/recOrder/plugin/widget/main_widget.py
@@ -2486,8 +2486,7 @@ class MainWidget(QWidget):
 
     @Slot(bool)
     def load_default_config(self):
-        self.config_reader = ConfigReader(mode='3D', method='QLIPP')
-        self._populate_from_config()
+        self.load_config("default_config.yml")
 
     @Slot(int)
     def update_sat_scale(self):

--- a/recOrder/plugin/widget/main_widget.py
+++ b/recOrder/plugin/widget/main_widget.py
@@ -21,6 +21,7 @@ from numpydoc.docscrape import NumpyDocString
 from packaging import version
 import numpy as np
 import os
+from os.path import dirname
 import json
 import logging
 import pathlib
@@ -271,7 +272,7 @@ class MainWidget(QWidget):
         self.worker = None
 
         # Display/Initialiaze GUI Images (plotting legends, recOrder logo)
-        recorder_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+        recorder_dir = dirname(dirname(dirname(dirname(os.path.abspath(__file__)))))
         jch_legend_path = os.path.join(recorder_dir, 'docs/images/JCh_legend.png')
         hsv_legend_path = os.path.join(recorder_dir, 'docs/images/HSV_legend.png')
         self.jch_pixmap = QPixmap(jch_legend_path)
@@ -280,6 +281,9 @@ class MainWidget(QWidget):
         logo_path = os.path.join(recorder_dir, 'docs/images/recOrder_plugin_logo.png')
         logo_pixmap = QPixmap(logo_path)
         self.ui.label_logo.setPixmap(logo_pixmap)
+
+        # Get default config file
+        self.default_config_file = os.path.join(recorder_dir, "recOrder/plugin/config_offline_default.yml")
 
         # Hide initial UI elements for later implementation or for later pop-up purposes
         self.ui.label_lca.hide()
@@ -2486,7 +2490,7 @@ class MainWidget(QWidget):
 
     @Slot(bool)
     def load_default_config(self):
-        self.load_config("default_config.yml")
+        self.load_config(self.default_config_file)
 
     @Slot(int)
     def update_sat_scale(self):


### PR DESCRIPTION
The 'Load Default Config' button no longer initiate values from `ConfigReader`, but read a config file at `recOrder/plugin/config_offline_default.yml`.