### PR TITLE
Block `imageio` versions that cause import error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ install_requires =
 	napari-ome-zarr>=0.3.2 # drag and drop convenience
 	qtpy # napari best practice (PyQt5 and PySide2 wrapper)
 	napari[all] # uses pip-installed PyQt5 by default
+	imageio!=2.11.0,!=2.22.1 # matching napari PR #5168, candidate for removal after the upstream issue is fixed
 	importlib-metadata
 
 [options.extras_require]


### PR DESCRIPTION
Now `napari` installed by `pip` on Windows 10 will not run when one of some specific versions of `imageio` is fetched. This issue is somehow not causing a failure in our test-and-deploy checks.
For releasing 0.2.0 we will be matching [`napari`'s solution](https://github.com/napari/napari/pull/5168).