### PR TITLE
git blame ignore squashed commit hash

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,4 +1,4 @@
 # .git-blame-ignore-revs
 # created as described in: https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view
 # black-format all `.py` files except recorder_ui.py
-958af2070cfb32397e7b7e8bfa7d022ec10b67af
+82f6df5ed34460374ce7c0fdca089d8caa570b9f


### PR DESCRIPTION
This repo squashes the commits when we merge a PR, so the `.git-blame-ignore-revs` file was ignoring a hash that no longer existed in the log. 

This PR updates now tell git blame to ignore the new squashed commit. 