### PR TITLE
Update development guide to install `waveorder` for co-development

### DIFF
--- a/.github/workflows/plugin_preview.yml
+++ b/.github/workflows/plugin_preview.yml
@@ -16,6 +16,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: napari hub Preview Page Builder
-        uses: chanzuckerberg/napari-hub-preview-action@v0.1.5
+        uses: chanzuckerberg/napari-hub-preview-action@v0.1
         with:
           hub-ref: main

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -92,7 +92,7 @@ Although many of `recOrder`'s tests are automated, many features require manual 
 
 We use `QT Creator` for large parts of `recOrder`'s GUI. To modify the GUI, install `QT Creator` from [its website](https://www.qt.io/product/development-tools) or with `brew install --cask qt-creator`
 
-Open `/recOrder/recOrder/plugin/qtdesigner/recOrder_ui.ui` in `QT Creator` and make your changes.
+Open `/recOrder/recOrder/plugin/gui.ui` in `QT Creator` and make your changes. 
 
 Finally, convert the `.ui` to a `.py` file with:
 
@@ -100,16 +100,16 @@ Finally, convert the `.ui` to a `.py` file with:
 pyuic5 -x gui.ui -o gui.py
 ```
 
+Note: `pyuic5` is installed alongside `PyQt5`, so you can expect to find it installed in your `recOrder` conda environement.
+
 Note: although much of the GUI is specified in the generated `recOrder_ui.py` file, the `main_widget.py` file makes extensive modifications to the GUI.
 
 ## Make `git blame` ignore formatting commits
+**Note:** `git --version` must be `>=2.23` to use this feature.
 
-> `git --version` must be `>=2.23` to use this feature.
-
-If you would like `git blame` to ignore formatting commits, run this line:
-
+If you would like `git blame` to ignore formatting commits, run this line: 
 ```sh
-git config --global blame.ignoreRevsFile .git-blame-ignore-revs
+ git config --global blame.ignoreRevsFile .git-blame-ignore-revs
 ```
 
 The `\.git-blame-ignore-revs` file contains a list of commit hashes corresponding to formatting commits. If you make a formatting commit, please add the commit's hash to this file.

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -92,7 +92,7 @@ Although many of `recOrder`'s tests are automated, many features require manual 
 
 We use `QT Creator` for large parts of `recOrder`'s GUI. To modify the GUI, install `QT Creator` from [its website](https://www.qt.io/product/development-tools) or with `brew install --cask qt-creator`
 
-Open `/recOrder/recOrder/plugin/gui.ui` in `QT Creator` and make your changes. 
+Open `/recOrder/recOrder/plugin/qtdesigner/recOrder_ui.ui` in `QT Creator` and make your changes.
 
 Finally, convert the `.ui` to a `.py` file with:
 
@@ -100,16 +100,16 @@ Finally, convert the `.ui` to a `.py` file with:
 pyuic5 -x gui.ui -o gui.py
 ```
 
-Note: `pyuic5` is installed alongside `PyQt5`, so you can expect to find it installed in your `recOrder` conda environement.
-
 Note: although much of the GUI is specified in the generated `recOrder_ui.py` file, the `main_widget.py` file makes extensive modifications to the GUI.
 
 ## Make `git blame` ignore formatting commits
-**Note:** `git --version` must be `>=2.23` to use this feature.
 
-If you would like `git blame` to ignore formatting commits, run this line: 
+> `git --version` must be `>=2.23` to use this feature.
+
+If you would like `git blame` to ignore formatting commits, run this line:
+
 ```sh
- git config --global blame.ignoreRevsFile .git-blame-ignore-revs
+git config --global blame.ignoreRevsFile .git-blame-ignore-revs
 ```
 
 The `\.git-blame-ignore-revs` file contains a list of commit hashes corresponding to formatting commits. If you make a formatting commit, please add the commit's hash to this file.

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -32,6 +32,22 @@
     pip install -e ".[dev]"
     ```
 
+4. Optionally, for the co-development of [`waveorder`](https://github.com/mehta-lab/waveorder) and `recOrder`:
+
+    > Note that `pip` will raise an 'error' complaining that the dependency of `recOrder-napari` has been broken if you do the following.
+    > This does not affect the installation, but can be suppressed by removing [this line](https://github.com/mehta-lab/recOrder/blob/5bc9314a9bacf6f4e235eaffb06c297cf20e4b65/setup.cfg#L40) before installing `waveorder`.
+    > (Just remember to revert the change afterwards!)
+    > We expect a nicer behavior to be possible once we release a stable version of `waveorder`.
+
+    ```sh
+    cd # where you want to clone the repo
+    git clone https://github.com/mehta-lab/waveorder.git
+    pip install ./waveorder -e ".[dev]"
+    ```
+
+    > Importing from a local and/or editable package can cause issues with static code analyzers such due to the absence of the source code from the paths they expect.
+    > VS Code users can refer to [this guide](https://github.com/microsoft/pylance-release/blob/main/TROUBLESHOOTING.md#common-questions-and-issues) to resolve typing warnings.
+
 ## Set up a development environment
 
 ### Code linting
@@ -78,11 +94,13 @@ We use `QT Creator` for large parts of `recOrder`'s GUI. To modify the GUI, inst
 
 Open `/recOrder/recOrder/plugin/gui.ui` in `QT Creator` and make your changes. 
 
-Finally, convert the `.ui` to a `.py` file with 
+Finally, convert the `.ui` to a `.py` file with:
+
 ```sh
 pyuic5 -x gui.ui -o gui.py
 ```
-Note: `pyuic5` is installed alongside `PyQt5`, so you can expect to find it installed in your `recOrder` conda environement. 
+
+Note: `pyuic5` is installed alongside `PyQt5`, so you can expect to find it installed in your `recOrder` conda environement.
 
 Note: although much of the GUI is specified in the generated `recOrder_ui.py` file, the `main_widget.py` file makes extensive modifications to the GUI.
 


### PR DESCRIPTION
To address #231.

<del>
This quick attempt may not be a good long-term solution if we plan to release unstable `waveorder` to PyPI in the future. (Then we will have to pin the `waveorder` version manually before each release.)
</del>(Not an appropriate solution.)

*Update: It seems like we can just ignore the 'error' message from `pip install ./waveorder -e ".[dev]"` when we already have `recOrder` installed -- the editable installations still work.*

Alternatively, we can:

In the `[options.extras_require]` section of `setup.cfg`, add a switch for different `waveorder` versions. But this will complicate `pip isntall` on the user side. An example is how [napari handles different Qt backends](https://github.com/napari/napari/blob/c305b4607569b963ca4862172e9ef8a9715b52bc/setup.cfg#L91-L107):
```cfg
[options.extras_require]
pyside2 =
    PySide2>=5.13.2,!=5.15.0 ; python_version != '3.8'
    PySide2>=5.14.2,!=5.15.0 ; python_version == '3.8'
pyside =  # alias for pyside2
    %(pyside2)s
pyqt5 =
    PyQt5>=5.12.3,!=5.15.0
pyqt =  # alias for pyqt5
    %(pyqt5)s
qt =  # alias for pyqt5
    %(pyqt5)s
# all is the full "batteries included" extra.
all =
    scikit-image[data]
    %(pyqt5)s
```