### PR TITLE
Test MM Core calls with mocks

### DIFF
--- a/recOrder/tests/mmcore_tests/test_core_func.py
+++ b/recOrder/tests/mmcore_tests/test_core_func.py
@@ -1,0 +1,108 @@
+from unittest.mock import MagicMock, Mock, PropertyMock
+from numpy.random import randint
+
+# tested components
+from recOrder.io.core_functions import *
+
+
+# dynamic range
+TIFF_I_MAX = 2**16
+# image size
+IMAGE_WIDTH = randint(1, 2**12)
+IMAGE_HEIGHT = randint(1, 2**12)
+PIXEL_COUNT = IMAGE_HEIGHT * IMAGE_WIDTH
+# serialized image from the pycromanager bridge
+SERIAL_IMAGE = randint(0, TIFF_I_MAX, size=(PIXEL_COUNT))
+
+
+def get_mmcore_mock():
+    """Creates a mock for the `pycromanager.Core` object.
+
+    Returns
+    -------
+    MagicMock
+        MMCore mock object
+    """
+    mmcore_mock_config = {"getImage": Mock(return_value=SERIAL_IMAGE)}
+    return MagicMock(**mmcore_mock_config)
+
+
+def get_snap_manager_mock():
+    """Creates a mock for the pycromanager remote Snap Live Window Manager object.
+
+    Returns
+    -------
+    MagicMock
+        Mock object for `org.micromanager.internal.SnapLiveManager` via pycromanager
+    """
+    sm = MagicMock()
+    get_snap_mocks = {
+        "getHeight": Mock(return_value=IMAGE_HEIGHT),
+        "getWidth": Mock(return_value=IMAGE_WIDTH),
+        "getRawPixels": Mock(return_value=SERIAL_IMAGE),
+    }
+    # TODO: break down these JAVA call stack chains for maintainability
+    sm.getDisplay.return_value.getDisplayedImages.return_value.get = Mock(
+        # return image object mock with H, W, and pixel values
+        return_value=Mock(**get_snap_mocks)
+    )
+    sm.getDisplay.return_value.getImagePlus.return_value.getStatistics = Mock(
+        # return statistics object mock with the attribute "umean"
+        return_value=Mock(umean=SERIAL_IMAGE.mean())
+    )
+    return sm
+
+
+def is_int(data):
+    """Check if the data type is integer.
+
+    Parameters
+    ----------
+    data
+
+    Returns
+    -------
+    bool
+        True if the data type is any integer type.
+    """
+    return np.issubdtype(data.dtype, np.integer)
+
+
+def test_snap_image():
+    """Test `recOrder.io.core_functions.snap_image`."""
+    mmc = get_mmcore_mock()
+    image = snap_image(mmc)
+    mmc.snapImage.assert_called_once()
+    mmc.getImage.assert_called_once()
+    assert is_int(image), image.dtype
+    assert image.shape == (PIXEL_COUNT,), image.shape
+
+
+def test_suspend_live_mm():
+    """Test `recOrder.io.core_functions.suspend_live_mm`."""
+    snap_manager = get_snap_manager_mock()
+    with suspend_live_sm(snap_manager) as sm:
+        sm.setSuspended.assert_called_once_with(True)
+    snap_manager.setSuspended.assert_called_with(False)
+
+
+def test_snap_and_get_image():
+    """Test `recOrder.io.core_functions.snap_and_get_image`."""
+    sm = get_snap_manager_mock()
+    image = snap_and_get_image(sm)
+    assert is_int(image), image.dtype
+    assert image.shape == (IMAGE_HEIGHT, IMAGE_WIDTH), image.shape
+
+
+def test_snap_and_average():
+    """Test `recOrder.io.core_functions.snap_and_average`."""
+    sm = get_snap_manager_mock()
+    mean = snap_and_average(sm)
+    assert mean == SERIAL_IMAGE.mean(), mean
+
+
+if __name__ == "__main__":
+    test_snap_image()
+    test_suspend_live_mm()
+    test_snap_and_get_image()
+    test_snap_and_average()

--- a/recOrder/tests/mmcore_tests/test_core_func.py
+++ b/recOrder/tests/mmcore_tests/test_core_func.py
@@ -23,7 +23,7 @@ DEVICE_PROPERTY = ("deviceName", "propertyName")
 CONFIG_GROUP = "configGroup"
 CONFIG_NAME = "State0"
 # LC state in native units
-LC_STATE = np.random.rand(1)[0] ** 10
+LC_STATE = np.random.rand(1)[0] * 10
 
 
 def _get_mmcore_mock():

--- a/recOrder/tests/mmcore_tests/test_core_func.py
+++ b/recOrder/tests/mmcore_tests/test_core_func.py
@@ -119,8 +119,8 @@ def test_snap_image():
     assert image.shape == (PIXEL_COUNT,), image.shape
 
 
-def test_suspend_live_mm():
-    """Test `recOrder.io.core_functions.suspend_live_mm`."""
+def test_suspend_live_sm():
+    """Test `recOrder.io.core_functions.suspend_live_sm`."""
     snap_manager = _get_snap_manager_mock()
     with suspend_live_sm(snap_manager) as sm:
         sm.setSuspended.assert_called_once_with(True)

--- a/recOrder/tests/mmcore_tests/test_core_func.py
+++ b/recOrder/tests/mmcore_tests/test_core_func.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, Mock, PropertyMock
+from unittest.mock import MagicMock, Mock
 from numpy.random import randint
 
 # tested components
@@ -99,10 +99,3 @@ def test_snap_and_average():
     sm = get_snap_manager_mock()
     mean = snap_and_average(sm)
     assert mean == SERIAL_IMAGE.mean(), mean
-
-
-if __name__ == "__main__":
-    test_snap_image()
-    test_suspend_live_mm()
-    test_snap_and_get_image()
-    test_snap_and_average()

--- a/recOrder/tests/mmcore_tests/test_core_func.py
+++ b/recOrder/tests/mmcore_tests/test_core_func.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, Mock, call
 import pytest
 import numpy as np
 from numpy import ndarray
-from typing import Callable
+from typing import Callable, Tuple
 
 # tested components
 from recOrder.io.core_functions import *
@@ -143,8 +143,8 @@ def test_snap_and_average():
 
 
 def _set_lc_test(
-    tested_func: Callable[[object, tuple[str, str], float], None],
-    value_range: tuple[float, float],
+    tested_func: Callable[[object, Tuple[str, str], float], None],
+    value_range: Tuple[float, float],
 ):
     mmc = _get_mmcore_mock()
     valid_values, invalid_values = _get_examples(*value_range)


### PR DESCRIPTION
Our test coverage has been declining. This is an initial attempt to address this problem by using simple mock-up objects to unit-test methods that make calls to Micro-Manger APIs.

On a side note, it may be beneficial if we isolated all outbound calls via `pycromanager` and aggregate them in the `io.core_functions` module.

Starting to address #156.