### PR TITLE
Turn off autoshutter before bg capture

### DIFF
--- a/recOrder/calib/Calibration.py
+++ b/recOrder/calib/Calibration.py
@@ -1071,9 +1071,10 @@ class QLIPP_Calibration:
         logging.info("Capturing Background")
         self._auto_shutter_state = self.mmc.getAutoShutter()
         self._shutter_state = self.mmc.getShutterOpen()
+        self.mmc.setAutoShutter(False)
         self.open_shutter()
-        logging.debug("Capturing Background State0")
 
+        logging.debug("Capturing Background State0")
         state0 = self._capture_state("State0", n_avg)
         logging.debug("Saving Background State0")
         tiff.imsave(os.path.join(directory, "State0.tif"), state0)


### PR DESCRIPTION
Fixes #237 

Note that turning off autoshutter does not require an automatic shutter, i.e. this code will run even if the microscope has only a manual shutter