### PR TITLE
Remove background debugging print statement

### DIFF
--- a/recOrder/compute/qlipp_compute.py
+++ b/recOrder/compute/qlipp_compute.py
@@ -16,7 +16,7 @@ def initialize_reconstructor(
     z_step_um=None,
     pad_z=0,
     pixel_size_um=None,
-    bg_correction="local_fit",
+    bg_correction="None",
     n_obj_media=1.0,
     mode="3D",
     use_gpu=False,

--- a/recOrder/compute/qlipp_compute.py
+++ b/recOrder/compute/qlipp_compute.py
@@ -193,7 +193,6 @@ def initialize_reconstructor(
 
     print("Initializing Reconstructor...")
     start_time = time.time()
-    print(bg_correction)
     recon = waveorder_microscopy(
         img_dim=image_dim,
         lambda_illu=lambda_illu,


### PR DESCRIPTION
This PR removes a debugging print statement that was left behind, solving #258. 

@mattersoflight brought up a potential concern that "local_fit" background corrections were being applied to phase reconstructions, but I have reread the code closely and found that this is not the case. Background corrections are only being applied to polarization acquisition. 