### PR TITLE
"Retardance + Orientation + Phase" in 2D mode averages over z for retardance and orientation instead of slicing

### DIFF
--- a/recOrder/acq/acquisition_workers.py
+++ b/recOrder/acq/acquisition_workers.py
@@ -894,7 +894,7 @@ class PolarizationAcquisitionWorker(WorkerBase):
         if self.mode == "all":
             if self.calib_window.acq_mode == "2D":
                 birefringence = reconstruct_qlipp_birefringence(
-                    stokes[:, stokes.shape[1] // 2, :, :], recon
+                    np.mean(stokes, axis=1), recon
                 )
             else:
                 birefringence = reconstruct_qlipp_birefringence(stokes, recon)


### PR DESCRIPTION
Fixes #265. 

Before this PR, if you clicked "Retardance + Orientation + Phase" in 2D mode, `recOrder` would acquire a 3D stack and only use the central slice to recover retardance and orientation. After this PR, `recOrder` will average over Z (in the background-corrected Stokes parameters) before reconstructing the retardance and orientation. 

This feature can be valuable for averaging over noise or small structures, but it also averages over the blurry defocus images which can reduce contrast in the final result. The old behavior---reconstructing retardance and orientation from a single slice---is still available to the user via the "Retardance + Orientation" button in 2D mode. 

The attached figure summarizes the fix. Note: the left and right columns use identical contrast limits.  
![output](https://user-images.githubusercontent.com/9554101/201998964-4d6a7f89-50c3-4409-9152-4f69fe104630.png)
