### PR TITLE
Add 3D->2D phase script and add `in_focus_slice` argument

### DIFF
--- a/examples/3D-bf-to-2D-phase.py
+++ b/examples/3D-bf-to-2D-phase.py
@@ -1,0 +1,65 @@
+from waveorder.io.reader import WaveorderReader
+from waveorder.io.writer import WaveorderWriter
+from recOrder.compute.qlipp_compute import (
+    initialize_reconstructor,
+    reconstruct_phase2D,
+)
+from datetime import datetime
+import numpy as np
+import napari
+
+timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+## Load a dataset
+
+# Option 1: use random data and run this script as is.
+data = np.random.random((11, 256, 256))  # (Z, Y, X)
+
+# Option 2: load from file
+# reader = WaveorderReader('/path/to/ome-tiffs/or/zarr/store/')
+# position, time, channel = 0, 0, 0
+# data = reader.get_array(position)[time, channel, ...]  # read 3D volume
+
+## Set up a reconstructor.
+Z, Y, X = data.shape
+reconstructor_args = {
+    "image_dim": (Y, X),
+    "mag": 20,  # magnification
+    "pixel_size_um": 6.5,  # pixel size in um
+    "n_slices": Z,  # number of slices in z-stack
+    "z_step_um": 2,  # z-step size in um
+    "in_focus_slice": None,  # integer, set to None to use the central slice
+    "wavelength_nm": 532,
+    "NA_obj": 0.4,  # numerical aperture of objective
+    "NA_illu": 0.2,  # numerical aperture of condenser
+    "n_obj_media": 1.0,  # refractive index of objective immersion media
+    "mode": "2D",  # phase reconstruction mode, "2D" or "3D"
+    "use_gpu": False,
+    "gpu_id": 0,
+}
+reconstructor = initialize_reconstructor(
+    pipeline="PhaseFromBF", **reconstructor_args
+)
+
+phase2D = reconstruct_phase2D(
+    data, reconstructor, method="Tikhonov", reg_p=1e0
+)
+print(f"Shape of 2D phase data: {np.shape(phase2D)}")
+
+## Save to zarr
+writer = WaveorderWriter("./output-phase")
+writer.create_zarr_root("phase_" + timestamp)
+writer.init_array(
+    position=0,
+    data_shape=(1, 1, 1, Y, X),
+    chunk_size=(1, 1, 1, Y, X),
+    chan_names=["Phase"],
+)
+writer.write(phase2D, p=0, t=0, c=0, z=0)
+
+# These lines opens the reconstructed images
+# Alternatively, drag and drop the zarr store into napari and use the recOrder-napari reader.
+v = napari.Viewer()
+v.add_image(data)
+v.add_image(phase2D)
+napari.run()

--- a/examples/3D-bf-to-3D-phase.py
+++ b/examples/3D-bf-to-3D-phase.py
@@ -13,23 +13,15 @@ timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
 ## Load a dataset
 
 # Option 1: use random data and run this script as is.
-data = np.random.random((41, 256, 256))  # (Z, Y, X)
-Z, Y, X = data.shape
+data = np.random.random((11, 256, 256))  # (Z, Y, X)
 
-# Option 2: use test data or previously acquired data.
-# For test data, use this link to download from Zenodo,
-# https://zenodo.org/record/6983916/files/recOrder_test_data.zip?download=1
-# unzip the folder, and modify test_data_root to point to the unzipped folder.
-# Uncomment the next 7 lines then run this script.
-# test_data_root = "/Users/talon.chandler/Downloads/recOrder_test_data/"
-# dataset = "2022_08_04_recOrder_pytest_20x_04NA_BF/"
-# reader = WaveorderReader(
-#    test_data_root + dataset + "2T_3P_16Z_128Y_256X_Kazansky_BF_1"
-# )
-# data = reader.get_array(0)[0, 0, ...]
-# Z, Y, X = data.shape
+# Option 2: load from file
+# reader = WaveorderReader('/path/to/ome-tiffs/or/zarr/store/')
+# position, time, channel = 0, 0, 0
+# data = reader.get_array(position)[time, channel, ...]  # read 3D volume
 
 ## Set up a reconstructor.
+Z, Y, X = data.shape
 reconstructor_args = {
     "image_dim": (Y, X),
     "mag": 20,  # magnification
@@ -37,13 +29,10 @@ reconstructor_args = {
     "n_slices": Z,  # number of slices in z-stack
     "z_step_um": 2,  # z-step size in um
     "wavelength_nm": 532,
-    "swing": 0.1,
-    "calibration_scheme": "4-State",  # "4-State" or "5-State"
     "NA_obj": 0.4,  # numerical aperture of objective
     "NA_illu": 0.2,  # numerical aperture of condenser
     "n_obj_media": 1.0,  # refractive index of objective immersion media
-    "pad_z": 0,  # slices to pad for phase reconstruction boundary artifacts
-    "bg_correction": "local_fit",  # BG correction method: "None", "local_fit", "global"
+    "pad_z": 5,  # slices to pad for phase reconstruction boundary artifacts
     "mode": "3D",  # phase reconstruction mode, "2D" or "3D"
     "use_gpu": False,
     "gpu_id": 0,
@@ -71,5 +60,6 @@ writer.write(phase3D, p=0, t=0, c=0, z=slice(0, Z))
 # These lines opens the reconstructed images
 # Alternatively, drag and drop the zarr store into napari and use the recOrder-napari reader.
 v = napari.Viewer()
+v.add_image(data)
 v.add_image(phase3D)
 napari.run()

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,33 @@
+# `recOrder` example scripts
+
+These scripts demonstrate three types of reconstruction:
+
+1. 3D brightfield data to 3D phase in `3D-bf-to-3D-phase.py`. 
+2. 3D brightfield data to 2D phase in `3D-bf-to-2D-phase.py`.
+3. 4D polarization data to retardance, orientation, and 3D phase in `recon-qlipp.py`.   
+
+## Getting started
+First, [install `recOrder`](../docs/software-installation-guide.md) and run these scripts with 
+```bash
+python <script-name.py>
+```
+Running any of these scripts without modification will test your installation by running a reconstruction on random data. A successful run will open a `napari` window with results reconstructed from random data. 
+
+Next, [download the test data from zenodo (47 MB)](https://zenodo.org/record/6983916/files/recOrder_test_data.zip?download=1), and modify the script to load the test data. For example, in `3D-bf-to-2D-phase.py`, replace `/path/to/ome-tiffs/or/zarr/store/` with `/path/to/recOrder_test_data/2022_08_04_recOrder_pytest_20x_04NA_BF/2T_3P_16Z_128Y_256X_Kazansky_BF_1`.
+
+Finally, modify the script to process your data. Start by loading your data (our readers currently support `.tiff`, `ome.tiff`, `NDTiff`, and `.zarr`, but any `numpy` array will work). Fill in your imaging parameters (or connect your metadata to these parameters), and prototype with a script. 
+
+We recommend prototyping a reconstruction with a single position and time point. You may need to test several regularization parameters to find a value that yields results that aren't too noisy or too smooth. 
+
+After prototyping, the script can be applied to multiple datasets with a python `for` loop (slowest), `multiprocessing` (faster), or `slurm` (fastest). 
+
+## FAQ
+Q: Which script should I use?
+
+A: If you are reconstructed data acquired with calibrated liquid-crystal polarizers, use `recon-qlipp.py`. Otherwise, you will need to decide between a 3D or 2D phase reconstruction. 
+
+If your downstream processing requires 3D information or if you're unsure, then you should use `3D-bf-to-3D-phase.py`. If your sample is very thin compared to the depth of field of the microscope, if you're in a noise-limited regime, or if your downstream processing requires 2D phase information, then you should use `3D-bf-to-2D-phase.py`. Empirically, we have found that `3D-bf-to-2D-phase.py` reduces the noise in our reconstructions because it uses 3D information to formulate a single phase estimate for each pixel. 
+
+Q: What regularization parameter should I use?
+
+We recommend testing over a few orders of magnitude and choosing a result that isn't too noisy or too smooth.

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,7 +19,7 @@ Finally, modify the script to process your data. Start by loading your data (our
 
 We recommend prototyping a reconstruction with a single position and time point. You may need to test several regularization parameters to find a value that yields results that aren't too noisy or too smooth. 
 
-After prototyping, the script can be applied to multiple datasets with a python `for` loop (slowest), `multiprocessing` (faster), or `slurm` (fastest). 
+After prototyping, the script can be applied to multiple datasets with a python `for` loop (slowest), `multiprocessing` (faster), or batch processing with an HPC scheduler e.g. `slurm` (fastest). 
 
 ## FAQ
 Q: Which script should I use?

--- a/examples/recon-qlipp.py
+++ b/examples/recon-qlipp.py
@@ -20,19 +20,12 @@ data = np.random.random((4, 16, 256, 256))  # (C, Z, Y, X)
 C, Z, Y, X = data.shape
 bg_data = np.random.random((4, 256, 256))  # (C, Y, X)
 
-# Option 2: use test data or previously acquired data.
-# For test data, use this link to download from Zenodo,
-# https://zenodo.org/record/6983916/files/recOrder_test_data.zip?download=1
-# unzip the folder, and modify test_data_root to point to the unzipped folder.
-# Uncomment the next 8 lines then run this script.
-# test_data_root = "/Users/talon.chandler/Downloads/recOrder_test_data/"
-# dataset = "2022_08_04_recOrder_pytest_20x_04NA/"
-# reader = WaveorderReader(
-#    test_data_root + dataset + "2T_3P_16Z_128Y_256X_Kazansky_1"
-# )
-# data = reader.get_array(0)[0, ...]
+# Option 2: load from file
+# reader = WaveorderReader('/path/to/ome-tiffs/or/zarr/store/')
+# position, time = 0, 0
+# data = reader.get_array(position)[time, ...]
 # C, Z, Y, X = data.shape
-# bg_data = load_bg(test_data_root + dataset + "BG/", height=Y, width=X)
+# bg_data = load_bg("/path/to/recorder/BG", height=Y, width=X)
 
 ## Set up a reconstructor.
 reconstructor_args = {
@@ -47,7 +40,7 @@ reconstructor_args = {
     "NA_obj": 0.4,  # numerical aperture of objective
     "NA_illu": 0.2,  # numerical aperture of condenser
     "n_obj_media": 1.0,  # refractive index of objective immersion media
-    "pad_z": 0,  # slices to pad for phase reconstruction boundary artifacts
+    "pad_z": 5,  # slices to pad for phase reconstruction boundary artifacts
     "bg_correction": "local_fit",  # BG correction method: "None", "local_fit", "global"
     "mode": "3D",  # phase reconstruction mode, "2D" or "3D"
     "use_gpu": False,
@@ -107,6 +100,7 @@ writer.write(phase3D, p=0, t=0, c=0, z=slice(0, Z))
 # These lines opens the reconstructed images
 # Alternatively, drag and drop the zarr store into napari and use the recOrder-napari reader.
 v = napari.Viewer()
+v.add_image(data)
 v.add_image(birefringence)
 v.add_image(phase3D)
 napari.run()

--- a/recOrder/compute/qlipp_compute.py
+++ b/recOrder/compute/qlipp_compute.py
@@ -14,6 +14,7 @@ def initialize_reconstructor(
     mag=None,
     n_slices=None,
     z_step_um=None,
+    in_focus_slice=None,
     pad_z=0,
     pixel_size_um=None,
     bg_correction="None",
@@ -58,6 +59,10 @@ def initialize_reconstructor(
 
         z_step_um          : float
                             z step size of the image space
+
+        in_focus_slice     : int or None
+                            index of the in-focus z slice used for 2D-from-3D reconstructions
+                            if None, the middle z slice is used as the in focus slice
 
         pad_z             : float
                             how many padding slices to add for phase computation
@@ -148,8 +153,12 @@ def initialize_reconstructor(
     lambda_illu = wavelength_nm / 1000 if wavelength_nm else None
     n_defocus = n_slices if n_slices else 0
     z_step_um = 0 if not z_step_um else z_step_um
+
+    if in_focus_slice is None:
+        in_focus_slice = n_defocus // 2
+
     z_defocus = (
-        -(np.r_[:n_defocus] - n_defocus // 2) * z_step_um
+        -(np.r_[:n_defocus] - in_focus_slice) * z_step_um
     )  # assumes stack starts from the bottom
     ps = pixel_size_um / mag if pixel_size_um else None
     cali = True


### PR DESCRIPTION
This PR 
- adds a new `example/3D-bf-to-2D-phase.py` script
- adds a new `in_focus_slice` argument to allow this scripts to easily specify an in-focus slice
- adds a `README` to the example scripts with pointers on how to use and develop them