### PR TITLE
Populate "BF Channel" list with presets containing keywords

### DIFF
--- a/docs/microscope-installation-guide.md
+++ b/docs/microscope-installation-guide.md
@@ -54,9 +54,17 @@ Add 5 presets to this group named `State0`, `State1`, `State2`, `State3`, and `S
 
 ![](https://github.com/mehta-lab/recOrder/blob/main/docs/images/create_preset.png)
 
+### (Optional) Enable "Phase From BF" acquisition
+
+If you would like to reconstruct phase from brightfield, add a `Micromanager` preset with brightfield properties (e.g. moving the polarization analyzer out the light path) and give the preset a name that contains one of the following case-insensitive keywords:
+
+`["bf", "brightfield", "bright", "labelfree", "label-free", "lf", "label"]`
+
+In `recOrder` you can select this preset using the `Acquisition Settings > BF Channel` dropdown menu. 
+
 ### Enable port access
 
-Finally, enable port access so that micromanager can communicate with recOrder through the `pycromanager` bridge. To do so open MM and navigate to `Tools > Options` and check the box that says `Run server on port 4827`
+Finally, enable port access so that `Micromanager` can communicate with recOrder through the `pycromanager` bridge. To do so open `Micromanager` and navigate to `Tools > Options` and check the box that says `Run server on port 4827`
 
 ![](https://github.com/mehta-lab/recOrder/blob/main/docs/images/run_port.png)
 

--- a/docs/microscope-installation-guide.md
+++ b/docs/microscope-installation-guide.md
@@ -58,7 +58,7 @@ Add 5 presets to this group named `State0`, `State1`, `State2`, `State3`, and `S
 
 If you would like to reconstruct phase from brightfield, add a `Micromanager` preset with brightfield properties (e.g. moving the polarization analyzer out the light path) and give the preset a name that contains one of the following case-insensitive keywords:
 
-`["bf", "brightfield", "bright", "labelfree", "label-free", "lf", "label"]`
+`["bf", "brightfield", "bright", "labelfree", "label-free", "lf", "label", "phase, "ph"]`
 
 In `recOrder` you can select this preset using the `Acquisition Settings > BF Channel` dropdown menu. 
 

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -136,7 +136,9 @@ class MainWidget(QWidget):
         )
 
         # This parameter seems to be wired differently than others...investigate later
-        self.ui.le_recon_wavelength.editingFinished.connect(self.enter_recon_wavelength)
+        self.ui.le_recon_wavelength.editingFinished.connect(
+            self.enter_recon_wavelength
+        )
         self.ui.le_recon_wavelength.setText("532")
         self.enter_recon_wavelength()
 
@@ -898,9 +900,21 @@ class MainWidget(QWidget):
                 self.ui.cb_config_group.addItem(group)
 
             # Populate the acquisition "BF channel" list with presets that contain any of these keywords
-            bf_keywords = ["bf", "brightfield", "bright", "labelfree", "label-free", "lf", "label"]
+            bf_keywords = [
+                "bf",
+                "brightfield",
+                "bright",
+                "labelfree",
+                "label-free",
+                "lf",
+                "label",
+                "phase",
+                "ph",
+            ]
             for ch in config_list:
-                if any([keyword.lower() in ch.lower() for keyword in bf_keywords]):
+                if any(
+                    [keyword.lower() in ch.lower() for keyword in bf_keywords]
+                ):
                     self.ui.cb_acq_channel.addItem(ch)
 
         if not config_group_found:

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -898,6 +898,7 @@ class MainWidget(QWidget):
                 self.ui.cb_config_group.addItem(group)
 
             # Populate the BF channel list with presets that contain any of these keywords
+            # Populate the acquisition "BF channel" list with presets that contain any of these keywords
             bf_keywords = ["bf", "brightfield", "bright", "labelfree", "label-free", "lf", "label", ]
             for ch in config_list:
                 if any([keyword.lower() in ch.lower() for keyword in bf_keywords]):

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -896,11 +896,13 @@ class MainWidget(QWidget):
                     )
                     config_group_found = True
                 self.ui.cb_config_group.addItem(group)
-            # not entirely sure what this part does, but I left it in
-            # I think it tried to find a channel such as 'BF'
+
+            # Populate the BF channel list with presets that contain any of these keywords
+            bf_keywords = ["BF", "bf", "Bf", "Brightfield", "brightfield"]
             for ch in config_list:
-                if ch not in self.calib_channels:
+                if any([keyword in ch for keyword in bf_keywords]):
                     self.ui.cb_acq_channel.addItem(ch)
+
         if not config_group_found:
             msg = (
                 f"No config group contains channels {self.calib_channels}. "

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -897,9 +897,8 @@ class MainWidget(QWidget):
                     config_group_found = True
                 self.ui.cb_config_group.addItem(group)
 
-            # Populate the BF channel list with presets that contain any of these keywords
             # Populate the acquisition "BF channel" list with presets that contain any of these keywords
-            bf_keywords = ["bf", "brightfield", "bright", "labelfree", "label-free", "lf", "label", ]
+            bf_keywords = ["bf", "brightfield", "bright", "labelfree", "label-free", "lf", "label"]
             for ch in config_list:
                 if any([keyword.lower() in ch.lower() for keyword in bf_keywords]):
                     self.ui.cb_acq_channel.addItem(ch)

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -898,9 +898,9 @@ class MainWidget(QWidget):
                 self.ui.cb_config_group.addItem(group)
 
             # Populate the BF channel list with presets that contain any of these keywords
-            bf_keywords = ["BF", "bf", "Bf", "Brightfield", "brightfield"]
+            bf_keywords = ["bf", "brightfield", "bright", "labelfree", "label-free", "lf", "label", ]
             for ch in config_list:
-                if any([keyword in ch for keyword in bf_keywords]):
+                if any([keyword.lower() in ch.lower() for keyword in bf_keywords]):
                     self.ui.cb_acq_channel.addItem(ch)
 
         if not config_group_found:


### PR DESCRIPTION
Before this PR, the "BF Channel" list would be populated with all MM presets, which would lead to confusing defaults like this:
<img width="631" alt="image" src="https://user-images.githubusercontent.com/9554101/203672274-4bae2df3-b10f-45db-ae2e-ba48f16e7eed.png">

After this PR, the "BF Channel" list will only contain MM presets that have any of the following case-insensitive keywords as a substring:
`["bf", "brightfield", "bright", "labelfree", "label-free", "lf", "label"]`

I checked these keywords against the latest MM configs on `CompMicro_MMConfigs` and tested in person on hummingbird and falcon. Feel free to suggest/add other keywords.

On hummingbird, the startup menus now look like this (similar on falcon):
![image](https://user-images.githubusercontent.com/9554101/203673691-3b1009a7-2a76-47ee-9f32-d09b6c7fb018.png)
