### PR TITLE
Check for non-physical NA arguments

### DIFF
--- a/recOrder/compute/qlipp_compute.py
+++ b/recOrder/compute/qlipp_compute.py
@@ -98,6 +98,11 @@ def initialize_reconstructor(
 
     anisotropy_only = False
 
+    if NA_obj > n_obj_media:
+        raise ValueError("Parameters are non-physical: NA_obj > n_obj_media")
+    if NA_illu > n_obj_media:
+        raise ValueError("Parameters are non-physical: NA_illu > n_obj_media")
+
     if pipeline == "QLIPP" or pipeline == "PhaseFromBF":
 
         if not NA_obj:


### PR DESCRIPTION
This PR throws a `ValueError` if the user requests a reconstruction with the illumination or detection NA are greater than the index of refraction of the media: these correspond to non-physical parameters. 

If the user uses, for example, NA_obj = 1.1 and n_obj_media = 1.0, the user would see:

Before this PR:
`RuntimeWarning: invalid value encountered in sqrt
  oblique_factor = ((1 - lambda_in**2 * fr**2) *Pupil_support)**(1/2) / lambda_in`
along with a `nan` reconstruction. 

After this PR:
`ValueError: Parameters are non-physical: NA_obj > n_obj_media` with no reconstruction. 