### PR TITLE
Keep shutter open during 2D phase acquisitions

### DIFF
--- a/recOrder/acq/acquisition_workers.py
+++ b/recOrder/acq/acquisition_workers.py
@@ -175,6 +175,7 @@ class BFAcquisitionWorker(WorkerBase):
             zstep=self.calib_window.z_step,
             save_dir=self.snap_dir,
             prefix=self.prefix,
+            keep_shutter_open_slices=True,
         )
 
         self._check_abort()


### PR DESCRIPTION
In #160 I changed the polarization acquisition buttons to keep the shutter open between channels and slices, but I failed to do the same for "2D phase acquisitions" (which actually acquires a 3D stack and reconstructs the 2D phase). This one-line PR makes the shutter behavior consistent and keeps the shutter open during 2D phase acquisitions. 