### PR TITLE
Disable "Phase From BF" button when no BF channel is found - add tooltip

### DIFF
--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -207,7 +207,7 @@ class MainWidget(QWidget):
         ]
         msg = (
             f"No brightfield channel found. If you would like to acquire phase from brightfield,"
-            " please restart recOrder after adding a new channel to MicroManager with one of the,"
+            " please restart recOrder after adding a new channel to MicroManager with one of the"
             " following case-insensitive keywords: "
         ) + ", ".join(self.bf_keywords)
         self.no_bf_msg = "\n".join(textwrap.wrap(msg, width=70))
@@ -2123,8 +2123,12 @@ class MainWidget(QWidget):
         }
         # TV-specific parameters
         if self.phase_regularizer == "TV":
-            gui_state["Phase Reconstruction Settings"]["Rho"] = float(self.ui.le_rho.text())
-            gui_state["Phase Reconstruction Settings"]["Iterations"] = int(self.ui.le_itr.text())
+            gui_state["Phase Reconstruction Settings"]["Rho"] = float(
+                self.ui.le_rho.text()
+            )
+            gui_state["Phase Reconstruction Settings"]["Iterations"] = int(
+                self.ui.le_itr.text()
+            )
         # save in YAML
         save_path = os.path.join(save_dir, "gui_state.yml")
         with open(save_path, "w") as f:

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -190,6 +190,7 @@ class MainWidget(QWidget):
         self.ui.qbutton_acq_phase_from_bf.clicked[bool].connect(
             self.acq_phase_from_bf
         )
+        self.bf_channel_found = False
         self.ui.qbutton_acq_ret_ori_phase.clicked[bool].connect(
             self.acq_ret_ori_phase
         )
@@ -928,7 +929,8 @@ class MainWidget(QWidget):
                     [keyword.lower() in ch.lower() for keyword in bf_keywords]
                 ):
                     self.ui.cb_acq_channel.addItem(ch)
-
+                    bf_channel_found = True
+                    
         if not config_group_found:
             msg = (
                 f"No config group contains channels {self.calib_channels}. "
@@ -938,6 +940,18 @@ class MainWidget(QWidget):
                 "border: 1px solid rgb(200,0,0);"
             )
             raise KeyError(msg)
+
+        if not bf_channel_found:
+            msg = (
+                f"No brightfield channel found. If you would like to acquire phase from brightfield,"
+                " please restart recOrder after adding a new channel to MicroManager with one of the,"
+                " following case-insensitive keywords: "
+            ) + ", ".join(bf_keywords)
+            wrapped_msg = "\n".join(textwrap.wrap(msg, width=70))
+            self.ui.qbutton_acq_phase_from_bf.disconnect()
+            self.ui.qbutton_acq_phase_from_bf.setStyleSheet("border: 1px solid rgb(65,72,81);")
+            self.ui.qbutton_acq_phase_from_bf.setToolTip(wrapped_msg)
+            self.ui.cb_acq_channel.setToolTip(wrapped_msg)
 
         # set startup LC control mode
         _devices = self.mmc.getLoadedDevices()

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -69,12 +69,14 @@ class MainWidget(QWidget):
         "phase",
         "ph",
     ]
-    msg = (
-        f"No brightfield channel found. If you would like to acquire phase from brightfield,"
-        " please restart recOrder after adding a new channel to MicroManager with one of the"
-        " following case-insensitive keywords: "
-    ) + ", ".join(bf_keywords)
-    no_bf_msg = "\n".join(textwrap.wrap(msg, width=70))
+    no_bf_msg = "\n".join(
+        textwrap.wrap(
+            f"No brightfield channel found. If you would like to acquire phase from brightfield,"
+            " please restart recOrder after adding a new channel to MicroManager with one of the"
+            " following case-insensitive keywords: ",
+            width=70,
+        )
+    )
 
     def __init__(self, napari_viewer: Viewer):
         super().__init__()

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -73,7 +73,7 @@ class MainWidget(QWidget):
         textwrap.wrap(
             f"No brightfield channel found. If you would like to acquire phase from brightfield,"
             " please restart recOrder after adding a new channel to MicroManager with one of the"
-            " following case-insensitive keywords: ",
+            " following case-insensitive keywords: " + ", ".join(bf_keywords),
             width=70,
         )
     )

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -56,6 +56,26 @@ class MainWidget(QWidget):
     # Initialize Custom Signals
     log_changed = Signal(str)
 
+    # Initialize class attributes
+    disabled_button_style = "border: 1px solid rgb(65,72,81);"
+    bf_keywords = [
+        "bf",
+        "brightfield",
+        "bright",
+        "labelfree",
+        "label-free",
+        "lf",
+        "label",
+        "phase",
+        "ph",
+    ]
+    msg = (
+        f"No brightfield channel found. If you would like to acquire phase from brightfield,"
+        " please restart recOrder after adding a new channel to MicroManager with one of the"
+        " following case-insensitive keywords: "
+    ) + ", ".join(bf_keywords)
+    no_bf_msg = "\n".join(textwrap.wrap(msg, width=70))
+
     def __init__(self, napari_viewer: Viewer):
         super().__init__()
         self.viewer = napari_viewer
@@ -69,7 +89,6 @@ class MainWidget(QWidget):
 
         # Set attributes need for enabling/disabling buttons
         self.bf_channel_found = False
-        self.no_bf_msg = ""
 
         # Disable buttons until connected to MM
         self._set_buttons_enabled(False)
@@ -194,23 +213,6 @@ class MainWidget(QWidget):
         self.ui.qbutton_acq_phase_from_bf.clicked[bool].connect(
             self.acq_phase_from_bf
         )
-        self.bf_keywords = [
-            "bf",
-            "brightfield",
-            "bright",
-            "labelfree",
-            "label-free",
-            "lf",
-            "label",
-            "phase",
-            "ph",
-        ]
-        msg = (
-            f"No brightfield channel found. If you would like to acquire phase from brightfield,"
-            " please restart recOrder after adding a new channel to MicroManager with one of the"
-            " following case-insensitive keywords: "
-        ) + ", ".join(self.bf_keywords)
-        self.no_bf_msg = "\n".join(textwrap.wrap(msg, width=70))
 
         self.ui.qbutton_acq_ret_ori_phase.clicked[bool].connect(
             self.acq_ret_ori_phase
@@ -613,17 +615,17 @@ class MainWidget(QWidget):
             action_button.setEnabled(val)
             if val:
                 action_button.setToolTip("")
-                action_button.setStyleSheet("border: 1px solid rgb(32,34,40);")
+                action_button.setStyleSheet(self.disabled_button_style)
             else:
                 action_button.setToolTip(
                     "Action temporarily disabled. Connect to MM or wait for acquisition to finish."
                 )
-                action_button.setStyleSheet("border: 1px solid rgb(65,72,81);")
+                action_button.setStyleSheet(self.disabled_button_style)
 
         if not self.bf_channel_found:
             self.ui.qbutton_acq_phase_from_bf.setEnabled(False)
             self.ui.qbutton_acq_phase_from_bf.setStyleSheet(
-                "border: 1px solid rgb(65,72,81);"
+                self.disabled_button_style
             )
             self.ui.qbutton_acq_phase_from_bf.setToolTip(self.no_bf_msg)
 
@@ -964,7 +966,7 @@ class MainWidget(QWidget):
         if not self.bf_channel_found:
             self.ui.qbutton_acq_phase_from_bf.disconnect()
             self.ui.qbutton_acq_phase_from_bf.setStyleSheet(
-                "border: 1px solid rgb(65,72,81);"
+                self.disabled_button_style
             )
             self.ui.qbutton_acq_phase_from_bf.setToolTip(self.no_bf_msg)
             self.ui.cb_acq_channel.setToolTip(self.no_bf_msg)


### PR DESCRIPTION
Fixes #293. 

When no brightfield preset is found in the MM config, `recOrder` will:

**Before this PR:** show a complete list of presets available and let the user acquire a brightfield stack from any of those presets. 
**After this PR:** disable the "Phase From BF" button, disable the "BF Channel" dropdown box (now empty). If the user mouses over either the disabled button or the disabled dropdown, the tooltip in the following screenshot will appear. 
<img width="610" alt="Screen Shot 2022-12-09 at 4 08 57 PM" src="https://user-images.githubusercontent.com/9554101/206816379-618984b7-e299-43cc-b16e-227c7a455f3c.png">

Note: the user can acquire "Retardance + Orientation" or "Retardance + Orientation + Phase" when no brightfield preset is found because those acquisitions do not require a brightfield channel. 

Edit: extra comma between "the" and "following" in screenshot above removed