### PR TITLE
added option to parse through TS or DAC

### DIFF
--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -1340,7 +1340,7 @@ class MainWidget(QWidget):
             memory = set()
             for i in range(cfg.size()):
                 prop = cfg.getSetting(i)
-                if "TS_DAC" in prop.getDeviceLabel():
+                if "TS" in prop.getDeviceLabel() and "DAC" in prop.getDeviceLabel():
                     dac = prop.getDeviceLabel()[-2:]
                     if dac not in memory:
                         self.ui.cb_lca.addItem("DAC" + dac)


### PR DESCRIPTION
There was no need to enumerate the devices as this reads the `State0` config properties and looks for devices with `TS`. As long as the channels have been set properly, the current implementation works well.

Additionally, there was no current need to add another dropbox for the DAC device, but perhaps in the future if users are are using DACs other than the triggerscope the if/else case should be changed to look for just `DAC` instead. 

Tested this on Mantis. Fixes #312 