### PR TITLE
Transpose + np.copy() + (fancy indexing and/or  `ndarray.copy()`) causes major slowdowns

### DIFF
--- a/recOrder/compute/reconstructions.py
+++ b/recOrder/compute/reconstructions.py
@@ -321,21 +321,10 @@ def reconstruct_qlipp_birefringence(stokes, recon):
                               volume of shape (C, Z, Y, X) or (C, Y, X) containing reconstructed birefringence data.
     """
 
-    if stokes.ndim == 4:
-        stokes = np.transpose(stokes, (0, 2, 3, 1))
-    elif stokes.ndim == 3:
-        pass
-    else:
+    if stokes.ndim != 4 and stokes.ndim != 3:
         raise ValueError(f"Incompatible stokes dimension: {stokes.shape}")
 
-    birefringence = recon.Polarization_recon(np.copy(stokes))
-
-    # Return the transposed birefringence array with channel first
-    return (
-        np.transpose(birefringence, (-4, -1, -3, -2))
-        if len(birefringence.shape) == 4
-        else birefringence
-    )
+    return recon.Polarization_recon(stokes)
 
 
 def reconstruct_phase2D(


### PR DESCRIPTION
Fixes [waveorder #102](https://github.com/mehta-lab/waveorder/issues/102).

**TL;DR: transposes and copies are slowing down the `recOrder`->`waveorder` inferface**

The `recOrder` -> `waveorder` adapter functions use transposes to bridge the gap between `recOrder`'s CZYX order and `waveorder`s CXYZ order. Transposes of >=3-dimensional arrays can result in non-contiguous views of the original arrays, and the copied versions also inhabit non-contiguous regions of memory. This means that `waveorder` is often receiving non-contiguous arrays. 

`numpy` functions give the correct answers when you pass non-contiguous arrays, but the results are often much slower. Fancy indexing, and `.copy` operations are particularly slow when they operate on non-contiguous arrays since they need to seek across a large region of memory. 

`waveorder_reconstructor.Polarization_recon` receives non-contiguous arrays and uses fancy indexing (e.g. `sa_wrapped[ret_wrapped < 0] += np.pi / 2`) and `.copy` operations (`Recon_para[0] = ret_wrapped.copy()`). The `.copy` operations are particularly slow when they receive non-contiguous arrays that they don't expect. 

Confusingly, `np.copy()` has different default behavior than `ndarray.copy()` (`np.copy` matches the layout, while `ndarray.copy` assumes `C-order` and is recommended by numpy). Here's a minimal working example to illustrate the difference in behavior (and the core source of slowdown that this PR fixes):

<details>
  <summary>Minimal example script (click to expand):</summary>

  ```py
import numpy as np
import time

for i in [3,4,5]:
    Z = 2**i
    print(f"Slices = {Z}")

    A = np.random.random((4,Z,2048,2048))
    At = np.transpose(A, (0,2,3,1))
    At_copy = np.copy(At)
    import pdb; pdb.set_trace()

    t = time.time()
    copy1 = A[0].copy()
    print(f'A[0].copy(): \t\t{time.time() - t:.2f}')

    t = time.time()
    copy2 =  np.copy(At[0])
    print(f'np.copy(At[0]): \t{time.time() - t:.2f}')

    t = time.time()
    copy2 =  At[0].copy()
    print(f'At[0].copy(): \t\t{time.time() - t:.2f}')
  ```
Results in:
```
Slices = 8
A[0].copy(): 		0.04
np.copy(At[0]): 	0.04
At[0].copy(): 		0.07
Slices = 16
A[0].copy(): 		0.07
np.copy(At[0]): 	0.07
At[0].copy(): 		2.38
Slices = 32
A[0].copy(): 		0.14
np.copy(At[0]): 	0.14
At[0].copy(): 		19.19
```
</details>

This PR is a first step towards unravelling these issues. The `Polarization_recon` function doesn't need any transposes (even though `recOrder` applies them), so we can get the correct results quickly by removing the transposes and their inverses. 

I suspect that we'll find other similar speedups across the `recOrder` -> `waveorder` interface, and I will start my search in commonly used areas with transposes and copies. The longest-term solutions will involve changing `waveorder` to use the CZYX order so that no transposes are necessary. 