### PR TITLE
Multiprocessing script for reconstructing multiple positions and times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,6 @@ dmypy.json
 */_version.py
 recOrder/_version.py
 *.autosave
+
+# example data
+/examples/data_temp/*

--- a/examples/README.md
+++ b/examples/README.md
@@ -39,7 +39,7 @@ The `multi-modal-recon.py` script demonstrates this type of reconstruction. We r
 
 ### 6. Parallelize over positions or time points
 
-Once you've settled on a script that performs a reconstruction, the script can be applied to multiple datasets with a python `for` loop (slowest), `multiprocessing` (faster), or batch processing with an HPC scheduler e.g. `slurm` (fastest). 
+Once you've settled on a script that performs a reconstruction, the script can be applied to multiple datasets with a python `for` loop (slowest), `multiprocessing` (faster, see `parallel-reconstruct.py` for an example), or batch processing with an HPC scheduler e.g. `slurm` (fastest). 
 
 ## FAQ
 1. **Q: Which script should I use?**

--- a/examples/parallel-reconstruct.py
+++ b/examples/parallel-reconstruct.py
@@ -1,0 +1,171 @@
+import shutil
+import os
+import numpy as np
+import multiprocessing as mp
+from tqdm import tqdm
+from wget import download
+from datetime import datetime
+from iohub import read_micromanager, open_ome_zarr
+from iohub.convert import TIFFConverter
+from recOrder.io.utils import load_bg
+from recOrder.compute.reconstructions import (
+    initialize_reconstructor,
+    reconstruct_qlipp_stokes,
+    reconstruct_qlipp_birefringence,
+    reconstruct_phase3D,
+)
+
+# This example demonstrates a 3D-pol-to-birfringence reconstruction applied
+# to each position and time point of a micromanager dataset. The example
+# uses multiprocessing to apply the reconstructions in parallel.
+
+# This example will download a ~50 MB test dataset to your working directory.
+
+N_processes = 1  # (should have at least this many cores available)
+
+
+def precomputation():
+
+    # download test data
+    data_folder = os.path.join(os.getcwd(), "data_temp")
+    os.makedirs(data_folder, exist_ok=True)
+    url = "https://zenodo.org/record/6983916/files/recOrder_test_data.zip?download=1"
+    zip_file = "recOrder_test_Data.zip"
+    output = os.path.join(data_folder, zip_file)
+    if not os.path.exists(output):
+        print("Downloading test files...")
+        download(url, out=output)
+        shutil.unpack_archive(output, extract_dir=data_folder)
+
+    temp_path = os.path.join(data_folder, "temp.zarr")
+    converter = TIFFConverter(
+        os.path.join(
+            data_folder,
+            "2022_08_04_recOrder_pytest_20x_04NA/2T_3P_16Z_128Y_256X_Kazansky_1",
+        ),
+        temp_path,
+    )
+    converter.run()
+
+    # setup input reader
+    reader = open_ome_zarr(temp_path, mode="r+")
+    T, C, Z, Y, X = reader["0/0/0"].data.shape
+    dtype = reader["0/0/0"].data.dtype
+    P = len(list(reader.positions()))
+    bg_data = load_bg(
+        os.path.join(data_folder, "2022_08_04_recOrder_pytest_20x_04NA/BG/"),
+        height=Y,
+        width=X,
+    )
+
+    # setup output zarr
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    writer = open_ome_zarr(
+        "./output/reconstructions_" + timestamp + ".zarr",
+        layout="hcs",
+        mode="w-",
+        channel_names=[
+            "Retardance",
+            "Orientation",
+            "BF - computed",
+            "DoP",
+            "Phase",
+        ],
+    )
+    for p in range(P):
+        position = writer.create_position("0", str(p), "0")
+        position.create_zeros(name="0", shape=(T, 5, Z, Y, X), dtype=dtype)
+
+    return (reader, bg_data, writer)
+
+
+# define the work to be done on a single process
+# in this example a single process will loop through a set of CZYX volumes, and
+# for each volume it will read the data, apply a reconstruction, then save the
+# result to a hcs-format zarr
+def single_process(i, reader, bg_data, writer, vol_start, vol_end):
+    T, C, Z, Y, X = reader["0/0/0"].data.shape
+    for vol in range(vol_start, vol_end + 1):
+        print("DEBUG:", i, vol)
+        p = int(np.floor(vol / T))
+        t = int(vol % T)
+        print(f"Reconstructing vol={vol}, pos={p}, time={t}")
+
+        data = reader["0/" + str(p) + "/0"]["0"][t, ...]
+
+        # Set up a reconstructor.
+        reconstructor_args = {
+            "image_dim": (Y, X),
+            "mag": 20,  # magnification
+            "pixel_size_um": 6.5,  # pixel size in um
+            "n_slices": Z,  # number of slices in z-stack
+            "z_step_um": 2,  # z-step size in um
+            "wavelength_nm": 532,
+            "swing": 0.1,
+            "calibration_scheme": "4-State",  # "4-State" or "5-State"
+            "NA_obj": 0.4,  # numerical aperture of objective
+            "NA_illu": 0.2,  # numerical aperture of condenser
+            "n_obj_media": 1.0,  # refractive index of objective immersion media
+            "pad_z": 5,  # slices to pad for phase reconstruction boundary artifacts
+            "bg_correction": "local_fit",  # BG correction method: "None", "local_fit", "global"
+            "mode": "3D",  # phase reconstruction mode, "2D" or "3D"
+            "use_gpu": False,
+            "gpu_id": 0,
+        }
+        reconstructor = initialize_reconstructor(
+            pipeline="QLIPP", **reconstructor_args
+        )
+
+        # Reconstruct background Stokes
+        bg_stokes = reconstruct_qlipp_stokes(bg_data, reconstructor)
+
+        # Reconstruct data Stokes w/ background correction
+        stokes = reconstruct_qlipp_stokes(data, reconstructor, bg_stokes)
+
+        # Reconstruct Birefringence from Stokes
+        # Shape of the output birefringence will be (C, Z, Y, X) where
+        # Channel order = Retardance [nm], Orientation [rad], Brightfield (S0), Degree of Polarization
+        birefringence = reconstruct_qlipp_birefringence(stokes, reconstructor)
+        birefringence[0] = (
+            birefringence[0]
+            / (2 * np.pi)
+            * reconstructor_args["wavelength_nm"]
+        )
+
+        # Reconstruct Phase3D from S0
+        S0 = birefringence[2]
+        phase3D = reconstruct_phase3D(
+            S0, reconstructor, method="Tikhonov", reg_re=1e-2
+        )
+
+        writer["0/" + str(p) + "/0"]["0"][t, 0:4] = birefringence
+        writer["0/" + str(p) + "/0"]["0"][t, 4] = phase3D
+
+
+# prepare the processes
+# we will apply the same reconstruction to each position and time point, so we
+# need to split the CZYX volumes among the processes
+if __name__ == "__main__":
+    reader, bg_data, writer = precomputation()
+    processes = []
+    V = len(list(reader.positions())) * reader["0/0/0"].data.shape[0]
+    vol_per_process = int(np.ceil(V / N_processes))
+    print("vol_per_process", vol_per_process)
+    for i in range(N_processes):
+        vol_start = i * vol_per_process
+        vol_end = np.minimum(vol_start + vol_per_process - 1, V - 1)
+        print(f"Preparing volumes {vol_start}-{vol_end} for process {i}")
+        processes.append(
+            mp.Process(
+                target=single_process,
+                args=(i, reader, bg_data, writer, vol_start, vol_end),
+            )
+        )
+    print("STARTING PROCESSES")
+    # run the processes
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join()
+
+    writer.close()

--- a/examples/parallel-reconstruct.py
+++ b/examples/parallel-reconstruct.py
@@ -90,7 +90,7 @@ def single_process(i, reader, bg_data, writer, vol_start, vol_end):
         t = int(vol % T)
         print(f"Reconstructing vol={vol}, pos={p}, time={t}")
 
-        data = reader["0/" + str(p) + "/0"]["0"][t, ...]
+        data = reader["0/" + str(p) + "/0"]["0"][t]
 
         # Set up a reconstructor.
         reconstructor_args = {

--- a/examples/parallel-reconstruct.py
+++ b/examples/parallel-reconstruct.py
@@ -14,18 +14,24 @@ from recOrder.compute.reconstructions import (
     reconstruct_phase3D,
 )
 
+timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
 # This example demonstrates a 3D-pol-to-birfringence reconstruction applied
 # to each position and time point of a micromanager dataset. The example
 # uses multiprocessing to apply the reconstructions in parallel.
 
-# This example will download a ~50 MB test dataset to your working directory.
+# This example will download a ~50 MB micro-manager test dataset to your
+# working directory, convert it to a zarr store, then reconstruct physical
+# paramaters from each position and time point.
 
 N_processes = 6  # (should have at least this many cores available)
 
 
 def precomputation():
 
-    # download test data
+    # download test data and convert to zarr
+    # use this section for a test run, then delete it and load directly from
+    # a zarr store for a real reconstruction run
     data_folder = os.path.join(os.getcwd(), "data_temp")
     os.makedirs(data_folder, exist_ok=True)
     url = "https://zenodo.org/record/6983916/files/recOrder_test_data.zip?download=1"
@@ -36,7 +42,7 @@ def precomputation():
         download(url, out=output)
         shutil.unpack_archive(output, extract_dir=data_folder)
 
-    temp_path = os.path.join(data_folder, "temp.zarr")
+    temp_path = os.path.join(data_folder, timestamp + "_temp.zarr")
     converter = TIFFConverter(
         os.path.join(
             data_folder,
@@ -58,7 +64,6 @@ def precomputation():
     )
 
     # setup output zarr
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     writer = open_ome_zarr(
         "./output/reconstructions_" + timestamp + ".zarr",
         layout="hcs",

--- a/examples/parallel-reconstruct.py
+++ b/examples/parallel-reconstruct.py
@@ -24,7 +24,10 @@ timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
 # working directory, convert it to a zarr store, then reconstruct physical
 # paramaters from each position and time point.
 
-N_processes = 6  # (should have at least this many cores available)
+# Choose the number of processes to parallel over.
+# You should have at least this many cores available with enough RAM
+# available to each process to complete the reconstruction.
+N_processes = 6
 
 
 def precomputation():

--- a/examples/parallel-reconstruct.py
+++ b/examples/parallel-reconstruct.py
@@ -2,7 +2,6 @@ import shutil
 import os
 import numpy as np
 import multiprocessing as mp
-from tqdm import tqdm
 from wget import download
 from datetime import datetime
 from iohub import read_micromanager, open_ome_zarr

--- a/examples/parallel-reconstruct.py
+++ b/examples/parallel-reconstruct.py
@@ -4,7 +4,7 @@ import numpy as np
 import multiprocessing as mp
 from wget import download
 from datetime import datetime
-from iohub import read_micromanager, open_ome_zarr
+from iohub import open_ome_zarr
 from iohub.convert import TIFFConverter
 from recOrder.io.utils import load_bg
 from recOrder.compute.reconstructions import (

--- a/examples/parallel-reconstruct.py
+++ b/examples/parallel-reconstruct.py
@@ -21,7 +21,7 @@ from recOrder.compute.reconstructions import (
 
 # This example will download a ~50 MB test dataset to your working directory.
 
-N_processes = 1  # (should have at least this many cores available)
+N_processes = 6  # (should have at least this many cores available)
 
 
 def precomputation():


### PR DESCRIPTION
Fixes #299.

This example script downloads the recOrder test dataset (if it hasn't already been downloaded), converts the MM dataset to zarr, then uses multiprocessing to read and write each position and time point into a new zarr store in parallel. 

I have confirmed a ~5.5-fold speedup processing this 6-volume (T=2, P=3) test dataset on the HPC login node. I was not able to get the same speedup on my local machine (weird macOS behavior with core handling?). 

Thanks @ziw-liu and @edyoshikun for your suggestions. I found that converting to zarr helped (as expected), and I found that using the HPC was essential...multiprocessing isn't working well locally.

@ziw-liu I'm happy to take suggestions for cleaning up this script. I'm still not sure how we can best deploy multiprocessing and slurm since in my experience they are so resource dependent and have so many moving parts.

@ieivanov this addresses the issue you opened. You're more than welcome to test and comment, but it's not strictly necessary since we can iterate on this script fairly quickly. 
