### PR TITLE
Depend on iohub tagged release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
 	napari;'arm64' in platform_machine # without Qt and skimage
 	PyQt6;'arm64' in platform_machine
 	importlib-metadata
-	iohub @ git+https://github.com/czbiohub/iohub.git@0625173#v0.1.0dev0 # TODO FIX THIS
+	iohub @ git+https://github.com/czbiohub/iohub.git@v0.1.0dev1
 	
 [options.extras_require]
 dev =


### PR DESCRIPTION
While testing I temporarily depended on a specific `iohub` commit instead of a tagged version. I just tagged the head of `iohub` and this PR makes `recOrder` depend on that tag. 

After this merges I'll tag `recOrder` with `0.3.0rc1`. 