### PR TITLE
Add overlay option to `view` command

### DIFF
--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -529,7 +529,6 @@ class MainWidget(QWidget):
         ui_slider.setRange(range_[0], range_[1])
 
     def _promote_slider_init(self):
-
         """
         Used to promote the Display Tab sliders from QSlider to QDoubeRangeSlider with superqt
         Returns
@@ -1160,7 +1159,6 @@ class MainWidget(QWidget):
             retardance=value[0],
             orientation=value[1],
             ret_max=np.percentile(value[0], 99.99),
-            mode=self.acq_mode,
             cmap=self.colormap,
         )
         overlay_worker.returned.connect(self._draw_bire_overlay)
@@ -1174,7 +1172,6 @@ class MainWidget(QWidget):
 
     @Slot(object)
     def handle_phase_image_update(self, value):
-
         name = "Phase2D" if self.acq_mode == "2D" else "Phase3D"
 
         # Add new layer if none exists, otherwise update layer data
@@ -2290,7 +2287,6 @@ class MainWidget(QWidget):
 
     @Slot(tuple)
     def update_dims(self, dims):
-
         if not self.pause_updates:
             self.viewer.dims.set_current_step(0, dims[0])
             self.viewer.dims.set_current_step(1, dims[1])
@@ -2299,7 +2295,6 @@ class MainWidget(QWidget):
             pass
 
     def _open_file_dialog(self, default_path, type):
-
         return self._open_dialog("select a directory", str(default_path), type)
 
     def _open_dialog(self, title, ref, type):

--- a/recOrder/scripts/cli.py
+++ b/recOrder/scripts/cli.py
@@ -208,7 +208,7 @@ e.g. \"-p 0\" for the 0th position. Accepts multiple positions e.g. \"-p 0/0/0
     position`
     """,
 )
-def view(filename, positions=None, layers=None, overlay=False):
+def view(filename, positions, layers, overlay):
     """View a dataset in napari"""
     click.echo(f"Reading file:\t {filename}")
     print_info(filename)

--- a/recOrder/scripts/cli.py
+++ b/recOrder/scripts/cli.py
@@ -1,6 +1,9 @@
 import click
 import napari
+
+v = napari.Viewer()  # open viewer right away to use on hpc
 import numpy as np
+from recOrder.io.utils import ret_ori_overlay
 from iohub.reader import print_info, _infer_format
 from iohub import read_micromanager, open_ome_zarr
 from iohub.reader_base import ReaderBase
@@ -112,14 +115,34 @@ def _build_name_lists(reader, positions, layers):
     return layer_names, slice_names
 
 
-def _create_napari_viewer(arrays, layers, layer_names, slice_names):
-    # Create and populate napari viewer
-    v = napari.Viewer()
-
+def _create_napari_viewer(arrays, layers, layer_names, slice_names, overlay):
     # Add arrays
     for i, array in enumerate(arrays):
         v.add_image(array, name=layer_names[i])
         v.layers[-1].reset_contrast_limits()
+
+        # Add overlays
+        if overlay:
+            try:
+                ret_ind = slice_names.index("Retardance")
+                ori_ind = slice_names.index("Orientation")
+            except:
+                raise ValueError(
+                    "No channels named 'Retardance' and 'Orientation'. --overlay option is unavailable."
+                )
+            ret = array[:, ret_ind, ...]
+            ori = array[:, ori_ind, ...]
+            overlay = ret_ori_overlay(
+                ret,
+                ori,
+                ret_max=np.percentile(ret, 99.99),
+                cmap="HSV",
+            )
+            v.add_image(
+                np.squeeze(overlay),
+                name=layer_names[i] + "ro-overlay",
+                rgb=True,
+            )
 
     # Cosmetic labelling
     v.text_overlay.visible = True
@@ -174,7 +197,18 @@ e.g. \"-p 0\" for the 0th position. Accepts multiple positions e.g. \"-p 0/0/0
     type=click.Choice(["position", "channel", "p", "c"]),
     help="Layers as 'position' ('p') or 'channel' ('c')",
 )
-def view(filename, positions=None, layers=None):
+@click.option(
+    "--overlay",
+    "-o",
+    is_flag=True,
+    default=False,
+    help="""
+    Computes a retardance-orientation HSV overlay layers. Requires channel 
+    names `Retardance` and `Orientation` to be present, and requires `--layers 
+    position`
+    """,
+)
+def view(filename, positions=None, layers=None, overlay=False):
     """View a dataset in napari"""
     click.echo(f"Reading file:\t {filename}")
     print_info(filename)
@@ -187,4 +221,4 @@ def view(filename, positions=None, layers=None):
     arrays = _build_array_list(reader, positions, layers)
     layer_names, slice_names = _build_name_lists(reader, positions, layers)
 
-    _create_napari_viewer(arrays, layers, layer_names, slice_names)
+    _create_napari_viewer(arrays, layers, layer_names, slice_names, overlay)

--- a/recOrder/scripts/cli.py
+++ b/recOrder/scripts/cli.py
@@ -140,7 +140,7 @@ def _create_napari_viewer(arrays, layers, layer_names, slice_names, overlay):
             )
             v.add_image(
                 np.squeeze(overlay),
-                name=layer_names[i] + "ro-overlay",
+                name=layer_names[i] + "-BirefringenceOverlay",
                 rgb=True,
             )
 


### PR DESCRIPTION
`iohub` is not planning direct support for saving and displaying RGB images (https://github.com/czbiohub/iohub/issues/74), so this PR provides a recOrder-specific way to create quick overlays. 

This adds an `-o` option to `recorder view` that adds an overlay layer, identical to what you see after an acquisition from the `recOrder` plugin. 

In the short-medium term I might be the only user for this option, but it's definitely a common use case for me. 