### PR TITLE
Slurm-scripts

### DIFF
--- a/examples/slurm-scripts/bire_recon/batch_bire_recon.sh
+++ b/examples/slurm-scripts/bire_recon/batch_bire_recon.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Download the file from the web
+url=https://zenodo.org/record/6983916/files/recOrder_test_data.zip
+zip_file=recOrder_test_data.zip
+
+# Check if the file already exists
+if [ -f $zip_file ]; then
+    echo "File already exists, skipping download."
+else
+    # Download the file
+    wget $url >> ./test.out
+    # Unzip the downloaded file
+    unzip $zip_file >> ./test.out
+fi
+
+# GLOBAL INPUTS for the reconstruction
+RAW_DATA=$(pwd)/2022_08_04_recOrder_pytest_20x_04NA/2T_3P_16Z_128Y_256X_Kazansky_1
+OUT_DIR=$(pwd)/2022_08_04_recOrder_pytest_20x_04NA/tmp_birefringence_recon.zarr
+BG_DATA=$(pwd)/2022_08_04_recOrder_pytest_20x_04NA/BG
+POSITIONS=3
+
+# Load the venviornments
+module load anaconda
+module load comp_micro
+# This assumes user has the latest and editable recOrder install into it's environment
+conda activate recorder-dev
+
+# #Setup an output log
+logpath=../slurm_output/bire
+mkdir -p $logpath
+rm ../slurm_output/bire/*.out
+
+#Run the scripts
+RAW_ZARR=$(python convert_to_zarr.py --input $RAW_DATA)
+ZARR_JOB_ID=$(sbatch --parsable create_empty_zarr.sh $RAW_ZARR $OUT_DIR)
+BIRE_JOB_ID=$(sbatch --parsable --array=0-$((POSITIONS-1)) -d after:$ZARR_JOB_ID+1 bire_multiproc.sh $RAW_ZARR $OUT_DIR $BG_DATA)
+

--- a/examples/slurm-scripts/bire_recon/bire_mp.py
+++ b/examples/slurm-scripts/bire_recon/bire_mp.py
@@ -1,0 +1,140 @@
+# %%%
+from iohub.reader import read_micromanager
+from iohub.ngff import open_ome_zarr
+from recOrder.io.utils import load_bg
+import numpy as np
+import multiprocessing as mp
+from recOrder.compute.reconstructions import (
+    initialize_reconstructor,
+    reconstruct_qlipp_stokes,
+)
+import cv2
+
+# debugging
+from tqdm import tqdm
+import click
+import os
+
+
+def mp_recon(args):
+    (
+        reader,
+        bg_stokes,
+        reconstructor,
+        reconstructor_args,
+        store_path,
+        stack_info,
+        states_chan,
+    ) = args
+    P, T, C_tot, Z, Y, X = stack_info
+    stack = reader.get_zarr(P)[T, min(states_chan) : max(states_chan) + 1, Z]
+    stack = np.expand_dims(stack, 1)
+    stokes = reconstruct_qlipp_stokes(
+        stack, reconstructor, bg_stokes=bg_stokes
+    )
+    birefringence = reconstructor.Polarization_recon(stokes)
+    birefringence[0] = (
+        birefringence[0] / (2 * np.pi) * reconstructor_args["wavelength_nm"]
+    )
+    with open_ome_zarr(store_path, mode="r+") as dataset:
+        stack = dataset["0/0/" + str(P) + "/0"]
+        # [Retardance, Orientation, BF, DoP]
+        stack[T, : len(states_chan), Z] = birefringence[:, 0]
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command()
+@click.help_option("-h", "--help")
+@click.option(
+    "--input",
+    required=True,
+    type=click.Path(exists=True),
+    help="path to the RAW Zarrstore",
+)
+@click.option(
+    "--output",
+    required=True,
+    type=str,
+    help="path to save the bire + fluor dataset (i.e /tmp)",
+)
+@click.option(
+    "--bg",
+    required=True,
+    type=click.Path(exists=True),
+    help="path to save the bire + fluor dataset (i.e /tmp)",
+)
+@click.option(
+    "-p",
+    required=True,
+    help="number of positions to be processed",
+)
+def bire_mp(input, output, bg, p):
+    p = int(p)
+    print(input)
+    print(output)
+
+    #  Setup Readers 0
+    reader = read_micromanager(input)
+    T, C, Z, Y, X = reader.shape
+    bg_data = load_bg(bg, height=Y, width=X)
+    channel_names = reader.channel_names
+    state_indices = [
+        i for i, elem in enumerate(channel_names) if elem.find("State") != -1
+    ]
+    bire_channels = 4     #[Ret, Ori, BF, DoP]
+    # Reconstruction Parameters
+    reconstructor_args = {
+        "image_dim": (Y, X),
+        "mag": 20,  # magnification
+        "pixel_size_um": 6.5,  # pixel size in um
+        "n_slices": Z,  # number of slices in z-stack
+        "z_step_um": 2,  # z-step size in um
+        "wavelength_nm": 532,
+        "swing": 0.1,
+        "calibration_scheme": "4-State",  # "4-State" or "5-State"
+        "NA_obj": 0.4,  # numerical aperture of objective
+        "NA_illu": 0.2,  # numerical aperture of condenser
+        "n_obj_media": 1.0,  # refractive index of objective immersion media
+        "pad_z": 5,  # slices to pad for phase reconstruction boundary artifacts
+        "bg_correction": "global",  # BG correction method: "None", "local_fit", "global"
+        "mode": "3D",  # phase reconstruction mode, "2D" or "3D"
+        "use_gpu": False,
+        "gpu_id": 0,
+    }
+    reconstructor = initialize_reconstructor(
+        pipeline="birefringence", **reconstructor_args
+    )
+    bg_stokes = reconstruct_qlipp_stokes(bg_data, reconstructor)
+
+    mp_args = []
+    for t in range(T):
+        for z in range(Z):
+            stack_info = (p, t, bire_channels, z, Y, X)
+            mp_args.append(
+                (
+                    reader,
+                    bg_stokes,
+                    reconstructor,
+                    reconstructor_args,
+                    output,
+                    stack_info,
+                    state_indices,
+                )
+            )
+    nProc = mp.cpu_count()
+    pool = mp.Pool(nProc)
+    print(nProc)
+    results = []
+    for result in tqdm(pool.imap(mp_recon, mp_args), total=len(mp_args)):
+        results.append(result)
+
+
+if __name__ == "__main__":
+    bire_mp()
+
+# %%
+##

--- a/examples/slurm-scripts/bire_recon/bire_multiproc.sh
+++ b/examples/slurm-scripts/bire_recon/bire_multiproc.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#SBATCH --job-name=BIRE_CONV
+#SBATCH --time=1:00:00
+#SBATCH --partition=cpu
+#SBATCH --cpus-per-task=1
+#SBATCH --mem-per-cpu=16G
+#SBATCH --output=../slurm_output/bire/bire-%A-%a.out
+env | grep "^SLURM" | sort
+
+RAW_DATA=$1
+OUT_BIRE=$2
+BG_DATA=$3
+
+module load anaconda
+module load comp_micro
+conda activate pyplay
+
+now=$(date '+%y-%m-%d')
+logpath=../logs/$now/bire
+mkdir -p $logpath
+logfile="$logpath/bire_conv_$SLURM_ARRAY_TASK_ID.out"
+
+echo  "raw:  $RAW_DATA " >> ${logfile}
+echo "out: $OUT_BIRE " >> ${logfile}
+echo "BG_DATA: $BG_DATA " >> ${logfile}
+echo "out: $SLURM_ARRAY_TASK_ID " >> ${logfile}
+python -u ./bire_mp.py --input "$RAW_DATA" --output "$OUT_BIRE" --bg "$BG_DATA" -p $SLURM_ARRAY_TASK_ID &>> ${logfile}

--- a/examples/slurm-scripts/bire_recon/convert_to_zarr.py
+++ b/examples/slurm-scripts/bire_recon/convert_to_zarr.py
@@ -1,0 +1,35 @@
+import click
+import os
+from datetime import datetime
+from iohub.convert import TIFFConverter
+
+timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command()
+@click.help_option("-h", "--help")
+@click.option(
+    "--input",
+    required=True,
+    type=click.Path(exists=True),
+    help="path to the RAW Zarrstore",
+)
+def convert_tiff_to_zarr(input):
+    # Store the zarr inside the dataset folder
+    datset_folder = os.path.join(input, os.pardir)
+    temp_path = os.path.join(
+        datset_folder, input + "_" + timestamp + "_tmp.zarr"
+    )
+    converter = TIFFConverter(input, temp_path)
+    converter.run()
+    print(temp_path)
+    return temp_path
+
+
+if __name__ == "__main__":
+    convert_tiff_to_zarr()

--- a/examples/slurm-scripts/bire_recon/create_empty_zarr.sh
+++ b/examples/slurm-scripts/bire_recon/create_empty_zarr.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+#SBATCH --job-name=ZARR_INIT
+#SBATCH --time=0:10:00
+#SBATCH --partition=cpu
+#SBATCH --cpus-per-task=1
+#SBATCH --mem-per-cpu=5G
+#SBATCH --output=../slurm_output/bire/zarr-%A-%a.out
+env | grep "^SLURM" | sort
+
+module load anaconda
+module load comp_micro
+conda activate pyplay
+
+RAW_DATA=$1
+OUT_DIR=$2
+
+now=$(date '+%y-%m-%d')
+logpath=../logs/$now/bire
+mkdir -p $logpath
+rm $logpath/*.out
+logfile="$logpath/Zarr.out"
+
+echo  "raw:  $RAW_DATA " >> ${logfile}
+echo "out: $OUT_DIR" >> ${logfile}
+python -u ./empty_zarr.py --input "$RAW_DATA" --output "$OUT_DIR" &>> ${logfile}
+ 

--- a/examples/slurm-scripts/bire_recon/empty_zarr.py
+++ b/examples/slurm-scripts/bire_recon/empty_zarr.py
@@ -1,0 +1,69 @@
+# %%%
+from iohub.reader import read_micromanager
+from iohub.ngff import open_ome_zarr
+
+# debugging
+from tqdm import tqdm
+import click
+import numpy as np
+from datetime import datetime
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command()
+@click.help_option("-h", "--help")
+@click.option(
+    "--input",
+    required=True,
+    type=click.Path(exists=True),
+    help="path to the RAW Zarrstore",
+)
+@click.option(
+    "--output",
+    required=True,
+    type=str,
+    help="path to save the bire + fluor dataset (i.e /tmp)",
+)
+def make_empty_array(input, output):
+    reader = read_micromanager(input)
+    T, C, Z, Y, X = reader.shape
+    num_positions = reader.get_num_positions()
+    channel_names = reader.channel_names
+    non_state_indices = [
+        i for i, elem in enumerate(channel_names) if elem.find("State") == -1
+    ]
+    # [Ret,Ori,BF,DoP + fluorescence channels]
+    recon_chan_names = ["Retardance", "Orientation", "BF - computed", "DoP"]
+    C_tot = len(recon_chan_names) + len(non_state_indices)
+
+    dchunks = (T, C_tot, Z, Y, X)
+    zchunks = (1, 1, 1, Y, X)
+    # Grab additional channel names typically from fluor channels and append
+    recon_chan_names.extend(channel_names[i] for i in non_state_indices)
+    with open_ome_zarr(
+        output,
+        layout="hcs",
+        mode="w-",
+        channel_names=recon_chan_names,
+    ) as dataset:
+        # Make the positions
+        for i in tqdm(range(num_positions)):
+            pos = dataset.create_position("0", "0", str(i))
+            # this is a 'hack' to create placeholder metadata
+            # future iohub should expose a public API for emtpy images
+            pos._create_image_meta("0")
+            arr = pos.zgroup.zeros(
+                "0",
+                shape=dchunks,
+                chunks=zchunks,
+                dtype=np.float32,
+                **pos._storage_options
+            )
+        dataset.print_tree()
+
+if __name__ == "__main__":
+    make_empty_array()

--- a/examples/slurm-scripts/bire_recon/empty_zarr.py
+++ b/examples/slurm-scripts/bire_recon/empty_zarr.py
@@ -33,6 +33,8 @@ def make_empty_array(input, output):
     T, C, Z, Y, X = reader.shape
     num_positions = reader.get_num_positions()
     channel_names = reader.channel_names
+    
+    #Check if the dataset contains other channels (i.e fluorescence)
     non_state_indices = [
         i for i, elem in enumerate(channel_names) if elem.find("State") == -1
     ]

--- a/examples/slurm-scripts/bire_recon/empty_zarr.py
+++ b/examples/slurm-scripts/bire_recon/empty_zarr.py
@@ -33,8 +33,8 @@ def make_empty_array(input, output):
     T, C, Z, Y, X = reader.shape
     num_positions = reader.get_num_positions()
     channel_names = reader.channel_names
-    
-    #Check if the dataset contains other channels (i.e fluorescence)
+
+    # Check if the dataset contains other channels (i.e fluorescence)
     non_state_indices = [
         i for i, elem in enumerate(channel_names) if elem.find("State") == -1
     ]
@@ -55,17 +55,15 @@ def make_empty_array(input, output):
         # Make the positions
         for i in tqdm(range(num_positions)):
             pos = dataset.create_position("0", "0", str(i))
-            # this is a 'hack' to create placeholder metadata
-            # future iohub should expose a public API for emtpy images
-            pos._create_image_meta("0")
-            arr = pos.zgroup.zeros(
-                "0",
+            arr = pos.create_zeros(
+                name="0",
                 shape=dchunks,
                 chunks=zchunks,
                 dtype=np.float32,
-                **pos._storage_options
             )
         dataset.print_tree()
+        dataset.print_tree()
+
 
 if __name__ == "__main__":
     make_empty_array()

--- a/examples/slurm-scripts/phase_recon/batch_phase_gpu.sh
+++ b/examples/slurm-scripts/phase_recon/batch_phase_gpu.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# GLOBAL INPUTS for the reconstruction
+BF_TIFF=../bire_recon/2022_08_04_recOrder_pytest_20x_04NA_BF/2T_3P_16Z_128Y_256X_Kazansky_BF_1
+OUT_DATA=$(pwd)/phase_reconstruction_tmp.zarr
+BG_DATA=../bire_recon/2022_08_04_recOrder_pytest_20x_04NA/BG
+POSITIONS=3
+
+# # Load the venviornments
+module load anaconda
+module load comp_micro
+# This assumes user has the latest and editable recOrder install into it's environment
+conda activate recorder-dev
+
+# Setup an output log
+logpath=../slurm_output/phase
+mkdir -p $logpath
+rm ../slurm_output/phase/*.out
+
+# Check if the reconstruction file exists
+if [ -d $BF_TIFF ]; then
+    echo "Folder exists"
+    echo $BF_TIFF
+else
+    echo "File does not exist. Running birefringence reconstruction"
+    $BIRE_BATCH=../bire_recon/batch_bire_recon.sh
+    . $BIRE_BATCH
+fi
+
+BF_ZARR=$(python ./convert_to_zarr.py --input $BF_TIFF)
+ZARR_JOB_ID=$(sbatch --parsable create_empty_zarr_phase.sh $BF_ZARR $OUT_DATA)
+PHASE_JOB_ID=$(sbatch --parsable --array=0-$((POSITIONS-1)) -d after:$ZARR_JOB_ID+1 phase_multiproc.sh $BF_ZARR $OUT_DATA)
+
+
+

--- a/examples/slurm-scripts/phase_recon/convert_to_zarr.py
+++ b/examples/slurm-scripts/phase_recon/convert_to_zarr.py
@@ -1,0 +1,35 @@
+import click
+import os
+from datetime import datetime
+from iohub.convert import TIFFConverter
+
+timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command()
+@click.help_option("-h", "--help")
+@click.option(
+    "--input",
+    required=True,
+    type=click.Path(exists=True),
+    help="path to the RAW Zarrstore",
+)
+def convert_tiff_to_zarr(input):
+    # Store the zarr inside the dataset folder
+    datset_folder = os.path.join(input, os.pardir)
+    temp_path = os.path.join(
+        datset_folder, input + "_" + timestamp + "_tmp.zarr"
+    )
+    converter = TIFFConverter(input, temp_path)
+    converter.run()
+    print(temp_path)
+    return temp_path
+
+
+if __name__ == "__main__":
+    convert_tiff_to_zarr()

--- a/examples/slurm-scripts/phase_recon/create_empty_zarr_phase.sh
+++ b/examples/slurm-scripts/phase_recon/create_empty_zarr_phase.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+#SBATCH --job-name=ZARR_INIT
+#SBATCH --time=0:10:00
+#SBATCH --partition=cpu
+#SBATCH --cpus-per-task=1
+#SBATCH --mem-per-cpu=5G
+#SBATCH --output=../slurm_output/phase/zarr-%A-%a.out
+env | grep "^SLURM" | sort
+
+module load anaconda
+module load comp_micro
+conda activate pyplay
+
+RAW_DATA=$1
+OUT_DATA=$2
+
+now=$(date '+%y-%m-%d')
+logpath=../logs/$now/phase
+mkdir -p $logpath
+rm $logpath/*.out
+logfile="$logpath/Zarr.out"
+
+echo  "raw:  $RAW_DATA " >> ${logfile}
+echo "out: $OUT_DATA " >> ${logfile}
+python -u ./empty_zarr_phase.py --input "$RAW_DATA" --output "$OUT_DATA" >> ${logfile}
+ 

--- a/examples/slurm-scripts/phase_recon/empty_zarr_phase.py
+++ b/examples/slurm-scripts/phase_recon/empty_zarr_phase.py
@@ -1,0 +1,66 @@
+# %%%
+from iohub.reader import read_micromanager
+from iohub.ngff import open_ome_zarr
+
+# debugging
+from tqdm import tqdm
+import click
+import numpy as np
+from datetime import datetime
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command()
+@click.help_option("-h", "--help")
+@click.option(
+    "--input",
+    required=True,
+    type=click.Path(exists=True),
+    help="path to the RAW Zarrstore",
+)
+@click.option(
+    "--output",
+    required=True,
+    type=str,
+    help="path to save the bire + fluor dataset (i.e /tmp)",
+)
+def make_empty_array(input, output):
+    # Define the Output path
+    reader = read_micromanager(input)
+    T, C, Z, Y, X = reader.shape
+    num_positions = reader.get_num_positions()
+    # [Ret,Ori,BF,DoP + fluorescence channels]
+    recon_chan_names = ["Phase 3D"]
+    C_tot = len(recon_chan_names)
+
+    dchunks = (T, C_tot, Z, Y, X)
+    zchunks = (1, 1, 1, Y, X)
+    # Grab additional channel names typically from fluor channels and append
+    with open_ome_zarr(
+        output,
+        layout="hcs",
+        mode="w-",
+        channel_names=recon_chan_names,
+    ) as dataset:
+        # Make the positions
+        for i in tqdm(range(num_positions)):
+            pos = dataset.create_position("position", str(i), "0")
+            # this is a 'hack' to create placeholder metadata
+            # future iohub should expose a public API for emtpy images
+            pos._create_image_meta("0")
+            arr = pos.zgroup.zeros(
+                "0",
+                shape=dchunks,
+                chunks=zchunks,
+                dtype=np.float32,
+                **pos._storage_options
+            )
+        dataset.print_tree()
+
+
+if __name__ == "__main__":
+    make_empty_array()

--- a/examples/slurm-scripts/phase_recon/empty_zarr_phase.py
+++ b/examples/slurm-scripts/phase_recon/empty_zarr_phase.py
@@ -49,15 +49,11 @@ def make_empty_array(input, output):
         # Make the positions
         for i in tqdm(range(num_positions)):
             pos = dataset.create_position("position", str(i), "0")
-            # this is a 'hack' to create placeholder metadata
-            # future iohub should expose a public API for emtpy images
-            pos._create_image_meta("0")
-            arr = pos.zgroup.zeros(
-                "0",
+            arr = pos.create_zeros(
+                name="0",
                 shape=dchunks,
                 chunks=zchunks,
                 dtype=np.float32,
-                **pos._storage_options
             )
         dataset.print_tree()
 

--- a/examples/slurm-scripts/phase_recon/phase_mp.py
+++ b/examples/slurm-scripts/phase_recon/phase_mp.py
@@ -1,0 +1,183 @@
+# %%
+import tempfile
+from datetime import datetime
+import numpy as np
+import os
+from recOrder.compute.reconstructions import (
+    initialize_reconstructor,
+    reconstruct_phase3D,
+)
+import waveorder as wo
+from iohub.reader import read_micromanager
+from iohub.ngff import open_ome_zarr
+
+# Only for GPU
+
+# debugging
+import time
+from tqdm import tqdm
+import click
+
+
+# %%
+@click.group()
+def cli():
+    pass
+
+
+@click.command()
+@click.option(
+    "--input",
+    required=True,
+    type=click.Path(exists=True),
+    help="RAW ZARR Path",
+)
+@click.option(
+    "--output",
+    required=True,
+    type=click.Path(exists=True),
+    help="Output zarr path",
+)
+@click.option("-p", required=True, help="Position")
+@click.option("--gpu", required=True, help="Nvidia-smi device number")
+def phase_mp(input, output, p, gpu):
+    print(f"USING GPU: {gpu}")
+    p = int(p)
+    reader = read_micromanager(input)
+    channel_names = reader.channel_names
+    BF_idx = [
+        i for i, elem in enumerate(channel_names) if elem.find("BF") != -1
+    ]
+    if len(BF_idx) < 1:
+        BF_idx = 0
+    print(f"Channels: {channel_names},BF_idx {BF_idx}")
+    T, C, Z, Y, X = reader.shape
+    print(f"Input array shape: {reader.shape}")
+
+    # %%
+    # Splitting the FOV
+    N_full = int(Y)
+    M_full = int(X)
+    overlapping_range = [0, 45]
+    max_image_size = [200, 200]
+    N_edge, N_space, M_space = wo.generate_FOV_splitting_parameters(
+        (N_full, M_full), overlapping_range, max_image_size
+    )
+    # Create sub-FOV list
+    Ns = N_space + N_edge
+    Ms = M_space + N_edge
+    ns, ms = wo.generate_sub_FOV_coordinates(
+        (Y, X), (N_space, M_space), (N_edge, N_edge)
+    )
+    # Get the chunk sizes and data shapes
+    row_list = (ns // N_space).astype("int")
+    column_list = (ms // M_space).astype("int")
+    # Chunking the data
+    dchunks = (1, 1, Z, int(Ns), int(Ms))
+    zchunks = (1, 1, 1, int(Ns), int(Ms))
+    # Create intermediate zarr store
+    tmp_store = f"{tempfile.gettempdir()}"
+    if not os.path.isdir(tmp_store):
+        os.mkdir(tmp_store)
+    timestamp = datetime.now().strftime("/phase_tiles_%d%H%M%S_")
+    tmp_store = tmp_store + timestamp + str(p) + ".zarr"
+    # Initialize the empty zarr store once for intermediate in  case of multiprocessing
+    with open_ome_zarr(
+        tmp_store,
+        layout="hcs",
+        mode="w-",
+        channel_names=["Phase_3D"],
+    ) as dataset:
+        # Make the positions
+        for i in tqdm(range(len(ns))):
+            pos = dataset.create_position("position", "0", str(i))
+            # this is a 'hack' to create placeholder metadata
+            # future iohub should expose a public API for emtpy images
+            pos._create_image_meta("0")
+            arr = pos.zgroup.zeros(
+                "0",
+                shape=dchunks,
+                chunks=zchunks,
+                dtype=np.float32,
+                **pos._storage_options,
+            )
+        dataset.print_tree()
+
+    # setup reconstructor.
+    reconstructor_args = {
+        "image_dim": (Ns, Ms),
+        "mag": 20,  # magnification
+        "pixel_size_um": 6.5,  # pixel size in um
+        "n_slices": Z,  # number of slices in z-stack
+        "z_step_um": 2,  # z-step size in um
+        "wavelength_nm": 532,
+        "swing": 0.1,
+        "calibration_scheme": "4-State",  # "4-State" or "5-State"
+        "NA_obj": 0.4,  # numerical aperture of objective
+        "NA_illu": 0.2,  # numerical aperture of condenser
+        "n_obj_media": 1.0,  # refractive index of objective immersion media
+        "pad_z": 5,  # slices to pad for phase reconstruction boundary artifacts
+        "bg_correction": "global",  # BG correction method: "None", "local_fit", "global"
+        "mode": "3D",  # phase reconstruction mode, "2D" or "3D"
+        "use_gpu": True,
+        "gpu_id": gpu,
+    }
+
+    reconstructor = initialize_reconstructor(
+        pipeline="QLIPP", **reconstructor_args
+    )
+
+    for t in range(T):
+        with open_ome_zarr(tmp_store, mode="r+") as dataset:
+            for ll in tqdm(range(len(ns))):
+                n_start = [int(ns[ll]), int(ms[ll])]
+                start_time = time.time()
+                S0 = reader.get_zarr(p)[
+                    t,
+                    BF_idx,
+                    :Z,
+                    n_start[0] : n_start[0] + Ns,
+                    n_start[1] : n_start[1] + Ms,
+                ]
+                print(S0.shape)
+                phase3D = reconstruct_phase3D(
+                    S0, reconstructor, method="Tikhonov", reg_re=5e-2
+                )
+                phase3D = phase3D[np.newaxis, ...]
+                # print(f"Shape of 3D phase data: {np.shape(phase3D)}")
+                # print(f'3D Phase elapsed time:{time.time() - start_time}')
+                print(
+                    "Finish process at (y, x) = (%d, %d), elapsed time: %.2f"
+                    % (ns[ll], ms[ll], time.time() - start_time)
+                )
+                stack = dataset["position/0/" + str(ll) + "/0"]
+                stack[0] = phase3D.astype(np.float32)
+        dataset.print_tree()
+
+        # Save the stitched results
+        # Open the tiled store path
+        tiled_dataset = open_ome_zarr(tmp_store, mode="r")
+        coord_list = (row_list, column_list)
+        overlap = (int(np.array(N_edge)), int(np.array(N_edge)))
+        # file_loading_func = lambda x: np.transpose(tiled_datset.get_zarr(x), (3, 4, 0, 1, 2))
+        file_loading_func = lambda x: np.transpose(
+            tiled_dataset["position/0/" + str(x) + "/0"], (3, 4, 0, 1, 2)
+        )
+        img_normalized, ref_stitch = wo.image_stitching(
+            coord_list,
+            overlap,
+            file_loading_func,
+            gen_ref_map=True,
+            ref_stitch=None,
+        )
+        tiled_dataset.close()
+        img_normalized = np.transpose(img_normalized, (2, 3, 4, 0, 1))
+        # %%
+        with open_ome_zarr(output, mode="r+") as dataset:
+            stack = dataset["position/" + str(p) + "/0/0"]
+            stack[t, 0, :Z, :Y, :X] = img_normalized[0, 0]
+        print(f"FINISHED t:{t},pos:{p}")
+
+
+if __name__ == "__main__":
+    phase_mp()

--- a/examples/slurm-scripts/phase_recon/phase_multiproc.sh
+++ b/examples/slurm-scripts/phase_recon/phase_multiproc.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#SBATCH --job-name=PHASE_CONV
+#SBATCH --time=2:00:00
+#SBATCH --partition=gpu
+#SBATCH --output=../slurm_output/phase/phaserecon-%A-%a.out
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --nodelist=gpu-c-1
+#SBATCH --reservation=bignode
+#SBATCH --gres=gpu:1
+#SBATCH --mem=64GB
+
+env | grep "^SLURM" | sort
+
+RAW_DATA=$1
+OUT_DATA=$2
+
+module load anaconda
+module load comp_micro
+conda activate pyplay
+
+now=$(date '+%y-%m-%d')
+logpath=../logs/$now/phase
+mkdir -p $logpath
+logfile="$logpath/phase_conv_$SLURM_ARRAY_TASK_ID.out"
+
+# echo $CUDA_VISIBLE_DEVICES
+echo "raw:  $RAW_DATA " >> ${logfile}
+echo "out: $OUT_DATA " >> ${logfile}
+echo "out: $SLURM_ARRAY_TASK_ID " >> ${logfile}
+
+python -u phase_mp.py --input "$RAW_DATA" --output "$OUT_DATA" -p $SLURM_ARRAY_TASK_ID  --gpu 0 >> ${logfile}


### PR DESCRIPTION
This PR adds examples on how to use slurm for parallel reconstructions for birefringence and phase. 

Both pipilines convert the data to zarr, create an empty zarr store for the output and parallelize the reconstructions per position to simultaneously write to the output zarr.

These scripts run using our zenodo dataset, but bigger datasets really take an advantage using HPC.