### PR TITLE
Pin README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,5 @@ Open `napari` with `recOrder-napari`:
 napari -w recOrder-napari
 ```
 
-For more help, see [`recOrder`'s documentation](./docs). To install `recOrder` 
-on a microscope, see the [microscope installation guide](./docs/microscope-installation-guide.md).
+For more help, see [`recOrder`'s documentation](https://github.com/mehta-lab/recOrder/tree/main/docs). To install `recOrder` 
+on a microscope, see the [microscope installation guide](https://github.com/mehta-lab/recOrder/blob/main/docs/microscope-installation-guide.md).


### PR DESCRIPTION
Similar to `https://github.com/mehta-lab/waveorder/pull/116`, two of the links on PyPI are broken. This PR pins the links. I think this issue is minor enough that is doesn't justify a rerelease, but I'm fixing this now so that we don't forget for the next release.  