### PR TITLE
`recOrder` buttons working via CLI 

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,5 @@ Open `napari` with `recOrder-napari`:
 napari -w recOrder-napari
 ```
 
-For more help, see [`recOrder`'s documentation](./docs). To install `recOrder` 
-on a microscope, see the [microscope installation guide](./docs/microscope-installation-guide.md).
+For more help, see [`recOrder`'s documentation](https://github.com/mehta-lab/recOrder/tree/main/docs). To install `recOrder` 
+on a microscope, see the [microscope installation guide](https://github.com/mehta-lab/recOrder/blob/main/docs/microscope-installation-guide.md).

--- a/recOrder/acq/acquisition_workers.py
+++ b/recOrder/acq/acquisition_workers.py
@@ -4,6 +4,13 @@ from __future__ import annotations
 from qtpy.QtCore import Signal
 from iohub import open_ome_zarr
 from iohub.convert import TIFFConverter
+from recOrder.cli import settings
+from recOrder.cli.compute_transfer_function import (
+    compute_transfer_function_cli,
+)
+from recOrder.cli.apply_inverse_transfer_function import (
+    apply_inverse_transfer_function_cli,
+)
 from recOrder.compute.reconstructions import (
     initialize_reconstructor,
     reconstruct_qlipp_birefringence,
@@ -29,6 +36,7 @@ import zarr
 import shutil
 import time
 import glob
+import yaml
 
 # type hint/check
 from typing import TYPE_CHECKING
@@ -37,6 +45,69 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from recOrder.plugin.main_widget import MainWidget
     from recOrder.calib.Calibration import QLIPP_Calibration
+
+
+def _generate_transfer_function_config(
+    transfer_function_settings_path, mode, calib_window, zyx_shape
+):
+    if mode == "birefringence":
+        reconstruct_phase = False
+        reconstruct_birefringence = True
+    elif mode == "phase":
+        reconstruct_phase = True
+        reconstruct_birefringence = False
+    elif mode == "all":
+        reconstruct_phase = True
+        reconstruct_birefringence = True
+
+    if calib_window.acq_mode == "2D":
+        reconstruction_dimension = 2
+    elif calib_window.acq_mode == "3D":
+        reconstruction_dimension = 3
+
+    universal_settings = settings._UniversalSettings(
+        reconstruct_phase=reconstruct_phase,
+        reconstruct_birefringence=reconstruct_birefringence,
+        reconstruction_dimension=reconstruction_dimension,
+        wavelength_illumination=calib_window.recon_wavelength / 1000,
+    )
+    birefringence_settings = settings._BirefringenceTransferFunctionSettings(
+        swing=calib_window.swing,
+        scheme=calib_window.calib_scheme,
+    )
+    phase_settings = settings._PhaseTransferFunctionSettings(
+        zyx_shape=zyx_shape,
+        yx_pixel_size=calib_window.ps / calib_window.mag,
+        z_pixel_size=calib_window.z_step,
+        z_padding=calib_window.pad_z,
+        index_of_refraction_media=calib_window.n_media,
+        numerical_aperture_illumination=calib_window.cond_na,
+        numerical_aperture_detection=calib_window.obj_na,
+    )
+    transfer_function_settings = settings.TransferFunctionSettings(
+        universal_settings=universal_settings,
+        birefringence_transfer_function_settings=birefringence_settings,
+        phase_transfer_function_settings=phase_settings,
+    )
+
+    with open(transfer_function_settings_path, "w") as f:
+        yaml.dump(transfer_function_settings.dict(), f)
+
+
+def _generate_apply_inverse_config(apply_inverse_settings_path, calib_window):
+    birefringence_apply_inverse_settings = (
+        settings._BirefringenceApplyInverseSettings()
+    )
+
+    phase_apply_inverse_settings = settings._PhaseApplyInverseSettings()
+
+    apply_inverse_settings = settings.ApplyInverseSettings(
+        birefringence_apply_inverse_settings=birefringence_apply_inverse_settings,
+        phase_apply_inverse_settings=phase_apply_inverse_settings,
+    )
+
+    with open(apply_inverse_settings_path, "w") as f:
+        yaml.dump(apply_inverse_settings.dict(), f)
 
 
 class PolarizationAcquisitionSignals(WorkerBaseSignals):
@@ -196,14 +267,14 @@ class BFAcquisitionWorker(WorkerBase):
         # Reconstruct snapped images
         self.n_slices = stack.shape[2]
 
-        phase, meta = self._reconstruct(stack[0])
+        phase = self._reconstruct()
         self._check_abort()
 
-        # Save images
-        logging.debug("Saving Images")
-        self._save_imgs(phase, meta)
+        # # Save images
+        # logging.debug("Saving Images")
+        # self._save_imgs(phase, meta)
 
-        self._check_abort()
+        # self._check_abort()
 
         logging.info("Finished Acquisition")
         logging.debug("Finished Acquisition")
@@ -211,155 +282,189 @@ class BFAcquisitionWorker(WorkerBase):
         # Emit the images and let thread know function is finished
         self.phase_image_emitter.emit(phase)
 
-    def _reconstruct(self, stack):
+    def _reconstruct(self):
         """
-        Method to reconstruct, given a 2D or 3D stack.
-        This function also checks to see if the reconstructor needs to be updated from previous acquisitions
-
-        Parameters
-        ----------
-        stack:          (nd-array) Dimensions are (C, Z, Y, X)
-
-        Returns
-        -------
-
+        Method to reconstruct
         """
-
-        self.img_dim = (stack.shape[-2], stack.shape[-1], stack.shape[-3])
         self._check_abort()
 
-        # Initialize the reconstuctor
-
-        # if no reconstructor has been initialized before, create new reconstructor
-        if not self.calib_window.phase_reconstructor:
-            logging.debug("Computing new reconstructor")
-
-            recon = initialize_reconstructor(
-                "PhaseFromBF",
-                image_dim=(stack.shape[-2], stack.shape[-1]),
-                wavelength_nm=self.calib_window.recon_wavelength,
-                NA_obj=self.calib_window.obj_na,
-                NA_illu=self.calib_window.cond_na,
-                mag=self.calib_window.mag,
-                n_slices=self.img_dim[-1],
-                z_step_um=self.calib_window.z_step,
-                pad_z=self.calib_window.pad_z,
-                pixel_size_um=self.calib_window.ps,
-                n_obj_media=self.calib_window.n_media,
-                mode=self.calib_window.acq_mode,
-                use_gpu=self.calib_window.use_gpu,
-                gpu_id=self.calib_window.gpu_id,
-            )
-
-            # Emit reconstructor to be saved for later reconstructions
-            self.phase_reconstructor_emitter.emit(recon)
-
-        # if previous reconstructor exists
-        else:
-            self._check_abort()
-
-            # compute new reconstructor if the old reconstructor properties have been modified
-            if self._reconstructor_changed(stack.shape):
-                logging.debug(
-                    "Reconstruction settings changed, updating reconstructor"
-                )
-
-                recon = initialize_reconstructor(
-                    "PhaseFromBF",
-                    image_dim=(stack.shape[-2], stack.shape[-1]),
-                    wavelength_nm=self.calib_window.recon_wavelength,
-                    NA_obj=self.calib_window.obj_na,
-                    NA_illu=self.calib_window.cond_na,
-                    mag=self.calib_window.mag,
-                    n_slices=self.n_slices,
-                    z_step_um=self.calib_window.z_step,
-                    pad_z=self.calib_window.pad_z,
-                    pixel_size_um=self.calib_window.ps,
-                    n_obj_media=self.calib_window.n_media,
-                    mode=self.calib_window.acq_mode,
-                    use_gpu=self.calib_window.use_gpu,
-                    gpu_id=self.calib_window.gpu_id,
-                )
-
-                # Emit reconstructor to be saved for later reconstructions
-                self.phase_reconstructor_emitter.emit(recon)
-
-            # use previous reconstructor
-            else:
-                logging.debug("Using previous reconstruction settings")
-                recon = self.calib_window.phase_reconstructor
-
-        # Begin reconstruction with stokes (needed for birefringence or phase)
-        logging.debug("Reconstructing...")
-        self._check_abort()
-
-        regularizer = self.calib_window.phase_regularizer
-        reg = float(self.calib_window.ui.le_phase_strength.text())
-
-        # Perform deconvolution
-        if self.dim == "2D":
-            phase = reconstruct_phase2D(
-                stack[0],
-                recon,
-                method=regularizer,
-                reg_p=reg,
-                itr=int(self.calib_window.ui.le_itr.text()),
-                rho=float(self.calib_window.ui.le_rho.text()),
-            )
-        else:
-            phase = reconstruct_phase3D(
-                stack[0],
-                recon,
-                method=regularizer,
-                reg_re=reg,
-                itr=int(self.calib_window.ui.le_itr.text()),
-                rho=float(self.calib_window.ui.le_rho.text()),
-            )
-
-        self._check_abort()
-
-        # Update metadata in zarr attributes with reconstruction parameters
-        meta = extract_reconstruction_parameters(
-            recon, magnification=self.calib_window.mag
+        # Create config and i/o paths
+        transfer_function_settings_path = os.path.join(
+            self.snap_dir, "transfer_function_settings.yml"
         )
-        meta["regularization_method"] = regularizer
-        meta["regularization_strength"] = reg
-        if regularizer == "TV":
-            meta["rho"] = float(self.calib_window.ui.le_rho.text())
-            meta["itr"] = int(self.calib_window.ui.le_itr.text())
-
-        # return both variables, could contain images or could be null
-        return phase, meta
-
-    def _save_imgs(self, phase, meta=None):
-        """
-        function to save images.
-
-        Parameters
-        ----------
-        phase:      (nd-array or None) phase image or stack
-
-        Returns
-        -------
-
-        """
-        prefix = self.calib_window.save_name
-        name = (
-            f"ReconstructionSnap.zarr"
-            if not prefix
-            else f"{prefix}_ReconstructionSnap.zarr"
+        transfer_function_path = os.path.join(
+            self.snap_dir, "transfer_function.zarr"
+        )
+        apply_inverse_settings_path = os.path.join(
+            self.snap_dir, "apply_inverse_settings.yml"
+        )
+        reconstruction_path = os.path.join(
+            self.snap_dir, "reconstruction.zarr"
         )
 
-        with open_ome_zarr(
-            os.path.join(self.snap_dir, name),
-            layout="fov",
-            mode="w-",
-            channel_names=["Phase" + str(phase.ndim) + "D"],
-        ) as dataset:
-            dataset["0"] = phase[
-                (5 - phase.ndim) * (np.newaxis,) + (Ellipsis,)
-            ]
-            dataset.zattrs["recOrder"] = meta
+        with open_ome_zarr(self.latest_out_path, mode="r") as dataset:
+            zyx_shape = dataset["0/0/0/0"].shape[2:]
+
+        _generate_transfer_function_config(
+            transfer_function_settings_path,
+            "phase",
+            self.calib_window,
+            zyx_shape,
+        )
+        compute_transfer_function_cli(
+            transfer_function_settings_path, transfer_function_path
+        )
+        _generate_apply_inverse_config(
+            apply_inverse_settings_path, self.calib_window
+        )
+        apply_inverse_transfer_function_cli(
+            os.path.join(self.latest_out_path, "0", "0", "0"),
+            transfer_function_path,
+            apply_inverse_settings_path,
+            reconstruction_path,
+        )
+
+        # Read reconstruction to pass to emitters
+        with open_ome_zarr(reconstruction_path, mode="r") as dataset:
+            phase = dataset["0"][0]
+
+        return phase
+
+        # self.img_dim = (stack.shape[-2], stack.shape[-1], stack.shape[-3])
+        # self._check_abort()
+
+        # # Initialize the reconstuctor
+
+        # # if no reconstructor has been initialized before, create new reconstructor
+        # if not self.calib_window.phase_reconstructor:
+        #     logging.debug("Computing new reconstructor")
+
+        #     recon = initialize_reconstructor(
+        #         "PhaseFromBF",
+        #         image_dim=(stack.shape[-2], stack.shape[-1]),
+        #         wavelength_nm=self.calib_window.recon_wavelength,
+        #         NA_obj=self.calib_window.obj_na,
+        #         NA_illu=self.calib_window.cond_na,
+        #         mag=self.calib_window.mag,
+        #         n_slices=self.img_dim[-1],
+        #         z_step_um=self.calib_window.z_step,
+        #         pad_z=self.calib_window.pad_z,
+        #         pixel_size_um=self.calib_window.ps,
+        #         n_obj_media=self.calib_window.n_media,
+        #         mode=self.calib_window.acq_mode,
+        #         use_gpu=self.calib_window.use_gpu,
+        #         gpu_id=self.calib_window.gpu_id,
+        #     )
+
+        #     # Emit reconstructor to be saved for later reconstructions
+        #     self.phase_reconstructor_emitter.emit(recon)
+
+        # # if previous reconstructor exists
+        # else:
+        #     self._check_abort()
+
+        #     # compute new reconstructor if the old reconstructor properties have been modified
+        #     if self._reconstructor_changed(stack.shape):
+        #         logging.debug(
+        #             "Reconstruction settings changed, updating reconstructor"
+        #         )
+
+        #         recon = initialize_reconstructor(
+        #             "PhaseFromBF",
+        #             image_dim=(stack.shape[-2], stack.shape[-1]),
+        #             wavelength_nm=self.calib_window.recon_wavelength,
+        #             NA_obj=self.calib_window.obj_na,
+        #             NA_illu=self.calib_window.cond_na,
+        #             mag=self.calib_window.mag,
+        #             n_slices=self.n_slices,
+        #             z_step_um=self.calib_window.z_step,
+        #             pad_z=self.calib_window.pad_z,
+        #             pixel_size_um=self.calib_window.ps,
+        #             n_obj_media=self.calib_window.n_media,
+        #             mode=self.calib_window.acq_mode,
+        #             use_gpu=self.calib_window.use_gpu,
+        #             gpu_id=self.calib_window.gpu_id,
+        #         )
+
+        #         # Emit reconstructor to be saved for later reconstructions
+        #         self.phase_reconstructor_emitter.emit(recon)
+
+        #     # use previous reconstructor
+        #     else:
+        #         logging.debug("Using previous reconstruction settings")
+        #         recon = self.calib_window.phase_reconstructor
+
+        # # Begin reconstruction with stokes (needed for birefringence or phase)
+        # logging.debug("Reconstructing...")
+        # self._check_abort()
+
+        # regularizer = self.calib_window.phase_regularizer
+        # reg = float(self.calib_window.ui.le_phase_strength.text())
+
+        # # Perform deconvolution
+        # if self.dim == "2D":
+        #     phase = reconstruct_phase2D(
+        #         stack[0],
+        #         recon,
+        #         method=regularizer,
+        #         reg_p=reg,
+        #         itr=int(self.calib_window.ui.le_itr.text()),
+        #         rho=float(self.calib_window.ui.le_rho.text()),
+        #     )
+        # else:
+        #     phase = reconstruct_phase3D(
+        #         stack[0],
+        #         recon,
+        #         method=regularizer,
+        #         reg_re=reg,
+        #         itr=int(self.calib_window.ui.le_itr.text()),
+        #         rho=float(self.calib_window.ui.le_rho.text()),
+        #     )
+
+        # self._check_abort()
+
+        # # Update metadata in zarr attributes with reconstruction parameters
+        # meta = extract_reconstruction_parameters(
+        #     recon, magnification=self.calib_window.mag
+        # )
+        # meta["regularization_method"] = regularizer
+        # meta["regularization_strength"] = reg
+        # if regularizer == "TV":
+        #     meta["rho"] = float(self.calib_window.ui.le_rho.text())
+        #     meta["itr"] = int(self.calib_window.ui.le_itr.text())
+
+        # # return both variables, could contain images or could be null
+        # return phase
+
+    # def _save_imgs(self, phase):
+    #     """
+    #     function to save images.
+
+    #     Parameters
+    #     ----------
+    #     phase:      (nd-array or None) phase image or stack
+
+    #     Returns
+    #     -------
+
+    #     """
+    #     prefix = self.calib_window.save_name
+    #     name = (
+    #         f"ReconstructionSnap.zarr"
+    #         if not prefix
+    #         else f"{prefix}_ReconstructionSnap.zarr"
+    #     )
+
+    #     with open_ome_zarr(
+    #         os.path.join(self.snap_dir, name),
+    #         layout="fov",
+    #         mode="w-",
+    #         channel_names=["Phase" + str(phase.ndim) + "D"],
+    #     ) as dataset:
+    #         dataset["0"] = phase[
+    #             (5 - phase.ndim) * (np.newaxis,) + (Ellipsis,)
+    #         ]
+    #         dataset.zattrs["recOrder"] = meta
 
     def _reconstructor_changed(self, stack_shape: tuple):
         """Function to check if the reconstructor has changed from the previous one in memory.
@@ -459,10 +564,10 @@ class BFAcquisitionWorker(WorkerBase):
                         if not save_prefix
                         else f"{save_prefix}_RawBFDataSnap.zarr"
                     )
-                    out_path = os.path.join(self.snap_dir, name)
+                    self.latest_out_path = os.path.join(self.snap_dir, name)
                     converter = TIFFConverter(
                         os.path.join(dir_, prefix),
-                        out_path,
+                        self.latest_out_path,
                         data_type="ometiff",
                         grid_layout=False,
                         label_positions=False,
@@ -615,17 +720,17 @@ class PolarizationAcquisitionWorker(WorkerBase):
         # Reconstruct snapped images
         self._check_abort()
         self.n_slices = stack.shape[2]
-        birefringence, phase, meta = self._reconstruct(stack[0])
+        birefringence, phase = self._reconstruct()
         self._check_abort()
 
         if self.calib_window.orientation_offset:
             birefringence = self._orientation_offset(birefringence)
 
         # Save images
-        logging.debug("Saving Images")
-        self._save_imgs(birefringence, phase, meta)
+        # logging.debug("Saving Images")
+        # self._save_imgs(birefringence, phase)
 
-        self._check_abort()
+        # self._check_abort()
 
         logging.info("Finished Acquisition")
         logging.debug("Finished Acquisition")
@@ -700,303 +805,349 @@ class PolarizationAcquisitionWorker(WorkerBase):
 
         return stack
 
-    def _reconstruct(self, stack):
+    def _reconstruct(self):
         """
-        Method to reconstruct, given a 2D or 3D stack.  First need to initialize the reconstructor given
+        Method to reconstruct.  First need to initialize the reconstructor given
         what type of acquisition it is (birefringence only skips a lot of heavy compute needed for phase).
         This function also checks to see if the reconstructor needs to be updated from previous acquisitions
 
-        Parameters
-        ----------
-        stack:          (nd-array) Dimensions are (C, Z, Y, X)
-
-        Returns
-        -------
-
         """
-
-        # get rid of z-dimension if 2D acquisition
-        stack = stack[:, 0] if self.n_slices == 1 else stack
-
         self._check_abort()
 
-        wo_background_correction = rec_bkg_to_wo_bkg(
-            self.calib_window.bg_option
+        # Create config and i/o paths
+        transfer_function_settings_path = os.path.join(
+            self.snap_dir, "transfer_function_settings.yml"
+        )
+        transfer_function_path = os.path.join(
+            self.snap_dir, "transfer_function.zarr"
+        )
+        apply_inverse_settings_path = os.path.join(
+            self.snap_dir, "apply_inverse_settings.yml"
+        )
+        reconstruction_path = os.path.join(
+            self.snap_dir, "reconstruction.zarr"
         )
 
-        # Initialize the heavy reconstuctor
-        if self.mode == "phase" or self.mode == "all":
-            self._check_abort()
+        with open_ome_zarr(self.latest_out_path, mode="r") as dataset:
+            zyx_shape = dataset["0/0/0/0"].shape[2:]
 
-            # if no reconstructor has been initialized before, create new reconstructor
-            if not self.calib_window.phase_reconstructor:
-                logging.debug("Computing new reconstructor")
+        _generate_transfer_function_config(
+            transfer_function_settings_path,
+            self.mode,
+            self.calib_window,
+            zyx_shape,
+        )
+        compute_transfer_function_cli(
+            transfer_function_settings_path, transfer_function_path
+        )
+        _generate_apply_inverse_config(
+            apply_inverse_settings_path, self.calib_window
+        )
+        apply_inverse_transfer_function_cli(
+            os.path.join(self.latest_out_path, "0", "0", "0"),
+            transfer_function_path,
+            apply_inverse_settings_path,
+            reconstruction_path,
+        )
 
-                recon = initialize_reconstructor(
-                    "QLIPP",
-                    image_dim=(stack.shape[-2], stack.shape[-1]),
-                    wavelength_nm=self.calib_window.recon_wavelength,
-                    swing=self.calib.swing,
-                    calibration_scheme=self.calib.calib_scheme,
-                    NA_obj=self.calib_window.obj_na,
-                    NA_illu=self.calib_window.cond_na,
-                    mag=self.calib_window.mag,
-                    n_slices=self.n_slices,
-                    z_step_um=self.calib_window.z_step,
-                    pad_z=self.calib_window.pad_z,
-                    pixel_size_um=self.calib_window.ps,
-                    bg_correction=wo_background_correction,
-                    n_obj_media=self.calib_window.n_media,
-                    mode=self.calib_window.acq_mode,
-                    use_gpu=self.calib_window.use_gpu,
-                    gpu_id=self.calib_window.gpu_id,
-                )
+        # Read reconstruction to pass to emitters
+        with open_ome_zarr(reconstruction_path, mode="r") as dataset:
+            czyx_data = dataset["0"][0]
+            birefringence = czyx_data[0:4]
+            try:
+                phase = czyx_data[4]
+            except:
+                phase = None
 
-                # Emit reconstructor to be saved for later reconstructions
-                self.phase_reconstructor_emitter.emit(recon)
+        return birefringence, phase
 
-            # if previous reconstructor exists
-            else:
-                self._check_abort()
+        # if self._reconstructor_changed():
+        # Generate transfer function settings and save to file
 
-                # compute new reconstructor if the old reconstructor properties have been modified
-                if self._reconstructor_changed():
-                    logging.debug(
-                        "Reconstruction settings changed, updating reconstructor"
-                    )
+        # Save to file
 
-                    recon = initialize_reconstructor(
-                        "QLIPP",
-                        image_dim=(stack.shape[-2], stack.shape[-1]),
-                        wavelength_nm=self.calib_window.recon_wavelength,
-                        swing=self.calib.swing,
-                        calibration_scheme=self.calib.calib_scheme,
-                        NA_obj=self.calib_window.obj_na,
-                        NA_illu=self.calib_window.cond_na,
-                        mag=self.calib_window.mag,
-                        n_slices=self.n_slices,
-                        z_step_um=self.calib_window.z_step,
-                        pad_z=self.calib_window.pad_z,
-                        pixel_size_um=self.calib_window.ps,
-                        bg_correction=wo_background_correction,
-                        n_obj_media=self.calib_window.n_media,
-                        mode=self.calib_window.acq_mode,
-                        use_gpu=self.calib_window.use_gpu,
-                        gpu_id=self.calib_window.gpu_id,
-                    )
+        # # get rid of z-dimension if 2D acquisition
+        # stack = stack[:, 0] if self.n_slices == 1 else stack
 
-                    self.phase_reconstructor_emitter.emit(recon)
+        # self._check_abort()
 
-                # use previous reconstructor
-                else:
-                    logging.debug("Using previous reconstruction settings")
-                    recon = self.calib_window.phase_reconstructor
+        # wo_background_correction = rec_bkg_to_wo_bkg(
+        #     self.calib_window.bg_option
+        # )
 
-        # if phase isn't desired, initialize the lighter birefringence only reconstructor
-        # no need to save this reconstructor for later as it is pretty quick to compute
-        else:
-            self._check_abort()
-            logging.debug("Creating birefringence only reconstructor")
-            recon = initialize_reconstructor(
-                "birefringence",
-                image_dim=(stack.shape[-2], stack.shape[-1]),
-                calibration_scheme=self.calib.calib_scheme,
-                wavelength_nm=self.calib_window.recon_wavelength,
-                swing=self.calib.swing,
-                bg_correction=wo_background_correction,
-                n_slices=self.n_slices,
-            )
+        # # Initialize the heavy reconstuctor
+        # if self.mode == "phase" or self.mode == "all":
+        #     self._check_abort()
 
-        # Prepare background corrections for waveorder
-        # This block mimics qlipp_pipeline.py L110-119.
-        if self.calib_window.bg_option in ["global", "local_fit+"]:
-            logging.debug("Loading BG Data")
-            self._check_abort()
-            bg_data = self._load_bg(
-                self.calib_window.acq_bg_directory,
-                stack.shape[-2],
-                stack.shape[-1],
-            )
-            self._check_abort()
-            bg_stokes = recon.Stokes_recon(bg_data)
-            self._check_abort()
-            bg_stokes = recon.Stokes_transform(bg_stokes)
-            self._check_abort()
-        elif self.calib_window.bg_option == "local_fit":
-            bg_stokes = np.zeros((5, stack.shape[-2], stack.shape[-1]))
-            bg_stokes[
-                0, ...
-            ] = 1  # Set background to "identity" Stokes parameters.
-        else:
-            logging.debug("No Background Correction method chosen")
-            bg_stokes = None
+        #     # if no reconstructor has been initialized before, create new reconstructor
+        #     if not self.calib_window.phase_reconstructor:
+        #         logging.debug("Computing new reconstructor")
 
-        # Begin reconstruction with stokes (needed for birefringence or phase)
-        logging.debug("Reconstructing...")
-        self._check_abort()
-        stokes = reconstruct_qlipp_stokes(stack, recon, bg_stokes)
-        self._check_abort()
+        #         recon = initialize_reconstructor(
+        #             "QLIPP",
+        #             image_dim=(stack.shape[-2], stack.shape[-1]),
+        #             wavelength_nm=self.calib_window.recon_wavelength,
+        #             swing=self.calib.swing,
+        #             calibration_scheme=self.calib.calib_scheme,
+        #             NA_obj=self.calib_window.obj_na,
+        #             NA_illu=self.calib_window.cond_na,
+        #             mag=self.calib_window.mag,
+        #             n_slices=self.n_slices,
+        #             z_step_um=self.calib_window.z_step,
+        #             pad_z=self.calib_window.pad_z,
+        #             pixel_size_um=self.calib_window.ps,
+        #             bg_correction=wo_background_correction,
+        #             n_obj_media=self.calib_window.n_media,
+        #             mode=self.calib_window.acq_mode,
+        #             use_gpu=self.calib_window.use_gpu,
+        #             gpu_id=self.calib_window.gpu_id,
+        #         )
 
-        # initialize empty variables to pass along
-        birefringence = None
-        phase = None
+        #         # Emit reconstructor to be saved for later reconstructions
+        #         self.phase_reconstructor_emitter.emit(recon)
 
-        regularizer = self.calib_window.phase_regularizer
+        #     # if previous reconstructor exists
+        #     else:
+        #         self._check_abort()
 
-        reg = float(self.calib_window.ui.le_phase_strength.text())
+        #         # compute new reconstructor if the old reconstructor properties have been modified
+        #         if self._reconstructor_changed():
+        #             logging.debug(
+        #                 "Reconstruction settings changed, updating reconstructor"
+        #             )
 
-        # reconstruct both phase and birefringence
-        if self.mode == "all":
-            if self.calib_window.acq_mode == "2D":
-                birefringence = reconstruct_qlipp_birefringence(
-                    np.mean(stokes, axis=1), recon
-                )
-            else:
-                birefringence = reconstruct_qlipp_birefringence(stokes, recon)
-            birefringence[0] = (
-                birefringence[0]
-                / (2 * np.pi)
-                * self.calib_window.recon_wavelength
-            )
-            self._check_abort()
+        #             recon = initialize_reconstructor(
+        #                 "QLIPP",
+        #                 image_dim=(stack.shape[-2], stack.shape[-1]),
+        #                 wavelength_nm=self.calib_window.recon_wavelength,
+        #                 swing=self.calib.swing,
+        #                 calibration_scheme=self.calib.calib_scheme,
+        #                 NA_obj=self.calib_window.obj_na,
+        #                 NA_illu=self.calib_window.cond_na,
+        #                 mag=self.calib_window.mag,
+        #                 n_slices=self.n_slices,
+        #                 z_step_um=self.calib_window.z_step,
+        #                 pad_z=self.calib_window.pad_z,
+        #                 pixel_size_um=self.calib_window.ps,
+        #                 bg_correction=wo_background_correction,
+        #                 n_obj_media=self.calib_window.n_media,
+        #                 mode=self.calib_window.acq_mode,
+        #                 use_gpu=self.calib_window.use_gpu,
+        #                 gpu_id=self.calib_window.gpu_id,
+        #             )
 
-            if self.calib_window.acq_mode == "2D":
-                phase = reconstruct_phase2D(
-                    stokes[0],
-                    recon,
-                    method=regularizer,
-                    reg_p=reg,
-                    itr=int(self.calib_window.ui.le_itr.text()),
-                    rho=float(self.calib_window.ui.le_rho.text()),
-                )
-            else:
-                phase = reconstruct_phase3D(
-                    stokes[0],
-                    recon,
-                    method=regularizer,
-                    reg_re=reg,
-                    itr=int(self.calib_window.ui.le_itr.text()),
-                    rho=float(self.calib_window.ui.le_rho.text()),
-                )
+        #             self.phase_reconstructor_emitter.emit(recon)
 
-            self._check_abort()
+        #         # use previous reconstructor
+        #         else:
+        #             logging.debug("Using previous reconstruction settings")
+        #             recon = self.calib_window.phase_reconstructor
 
-        # reconstruct phase only
-        elif self.mode == "phase":
-            if self.calib_window.acq_mode == "2D":
-                phase = reconstruct_phase2D(
-                    stokes[0],
-                    recon,
-                    method=regularizer,
-                    reg_p=reg,
-                    itr=int(self.calib_window.ui.le_itr.text()),
-                    rho=float(self.calib_window.ui.le_rho.text()),
-                )
-            else:
-                phase = reconstruct_phase3D(
-                    stokes[0],
-                    recon,
-                    method=regularizer,
-                    reg_re=reg,
-                    itr=int(self.calib_window.ui.le_itr.text()),
-                    rho=float(self.calib_window.ui.le_rho.text()),
-                )
-            self._check_abort()
+        # # if phase isn't desired, initialize the lighter birefringence only reconstructor
+        # # no need to save this reconstructor for later as it is pretty quick to compute
+        # else:
+        #     self._check_abort()
+        #     logging.debug("Creating birefringence only reconstructor")
+        #     recon = initialize_reconstructor(
+        #         "birefringence",
+        #         image_dim=(stack.shape[-2], stack.shape[-1]),
+        #         calibration_scheme=self.calib.calib_scheme,
+        #         wavelength_nm=self.calib_window.recon_wavelength,
+        #         swing=self.calib.swing,
+        #         bg_correction=wo_background_correction,
+        #         n_slices=self.n_slices,
+        #     )
 
-        # reconstruct birefringence only
-        elif self.mode == "birefringence":
-            birefringence = reconstruct_qlipp_birefringence(stokes, recon)
-            birefringence[0] = (
-                birefringence[0]
-                / (2 * np.pi)
-                * self.calib_window.recon_wavelength
-            )
-            self._check_abort()
+        # # Prepare background corrections for waveorder
+        # # This block mimics qlipp_pipeline.py L110-119.
+        # if self.calib_window.bg_option in ["global", "local_fit+"]:
+        #     logging.debug("Loading BG Data")
+        #     self._check_abort()
+        #     bg_data = self._load_bg(
+        #         self.calib_window.acq_bg_directory,
+        #         stack.shape[-2],
+        #         stack.shape[-1],
+        #     )
+        #     self._check_abort()
+        #     bg_stokes = recon.Stokes_recon(bg_data)
+        #     self._check_abort()
+        #     bg_stokes = recon.Stokes_transform(bg_stokes)
+        #     self._check_abort()
+        # elif self.calib_window.bg_option == "local_fit":
+        #     bg_stokes = np.zeros((5, stack.shape[-2], stack.shape[-1]))
+        #     bg_stokes[
+        #         0, ...
+        #     ] = 1  # Set background to "identity" Stokes parameters.
+        # else:
+        #     logging.debug("No Background Correction method chosen")
+        #     bg_stokes = None
 
-        else:
-            raise ValueError("Reconstruction Mode Not Understood")
+        # # Begin reconstruction with stokes (needed for birefringence or phase)
+        # logging.debug("Reconstructing...")
+        # self._check_abort()
+        # stokes = reconstruct_qlipp_stokes(stack, recon, bg_stokes)
+        # self._check_abort()
 
-        meta = extract_reconstruction_parameters(recon, self.calib_window.mag)
-        meta["regularization_method"] = regularizer
-        meta["regularization_strength"] = reg
-        if regularizer == "TV":
-            meta["rho"] = float(self.calib_window.ui.le_rho.text())
-            meta["itr"] = int(self.calib_window.ui.le_itr.text())
+        # # initialize empty variables to pass along
+        # birefringence = None
+        # phase = None
+
+        # regularizer = self.calib_window.phase_regularizer
+
+        # reg = float(self.calib_window.ui.le_phase_strength.text())
+
+        # # reconstruct both phase and birefringence
+        # if self.mode == "all":
+        #     if self.calib_window.acq_mode == "2D":
+        #         birefringence = reconstruct_qlipp_birefringence(
+        #             np.mean(stokes, axis=1), recon
+        #         )
+        #     else:
+        #         birefringence = reconstruct_qlipp_birefringence(stokes, recon)
+        #     birefringence[0] = (
+        #         birefringence[0]
+        #         / (2 * np.pi)
+        #         * self.calib_window.recon_wavelength
+        #     )
+        #     self._check_abort()
+
+        #     if self.calib_window.acq_mode == "2D":
+        #         phase = reconstruct_phase2D(
+        #             stokes[0],
+        #             recon,
+        #             method=regularizer,
+        #             reg_p=reg,
+        #             itr=int(self.calib_window.ui.le_itr.text()),
+        #             rho=float(self.calib_window.ui.le_rho.text()),
+        #         )
+        #     else:
+        #         phase = reconstruct_phase3D(
+        #             stokes[0],
+        #             recon,
+        #             method=regularizer,
+        #             reg_re=reg,
+        #             itr=int(self.calib_window.ui.le_itr.text()),
+        #             rho=float(self.calib_window.ui.le_rho.text()),
+        #         )
+
+        #     self._check_abort()
+
+        # # reconstruct phase only
+        # elif self.mode == "phase":
+        #     if self.calib_window.acq_mode == "2D":
+        #         phase = reconstruct_phase2D(
+        #             stokes[0],
+        #             recon,
+        #             method=regularizer,
+        #             reg_p=reg,
+        #             itr=int(self.calib_window.ui.le_itr.text()),
+        #             rho=float(self.calib_window.ui.le_rho.text()),
+        #         )
+        #     else:
+        #         phase = reconstruct_phase3D(
+        #             stokes[0],
+        #             recon,
+        #             method=regularizer,
+        #             reg_re=reg,
+        #             itr=int(self.calib_window.ui.le_itr.text()),
+        #             rho=float(self.calib_window.ui.le_rho.text()),
+        #         )
+        #     self._check_abort()
+
+        # # reconstruct birefringence only
+        # elif self.mode == "birefringence":
+        #     birefringence = reconstruct_qlipp_birefringence(stokes, recon)
+        #     birefringence[0] = (
+        #         birefringence[0]
+        #         / (2 * np.pi)
+        #         * self.calib_window.recon_wavelength
+        #     )
+        #     self._check_abort()
+
+        # else:
+        #     raise ValueError("Reconstruction Mode Not Understood")
+
+        # meta = extract_reconstruction_parameters(recon, self.calib_window.mag)
+        # meta["regularization_method"] = regularizer
+        # meta["regularization_strength"] = reg
+        # if regularizer == "TV":
+        #     meta["rho"] = float(self.calib_window.ui.le_rho.text())
+        #     meta["itr"] = int(self.calib_window.ui.le_itr.text())
 
         # return both variables, could contain images or could be null
-        return birefringence, phase, meta
+        # return birefringence, phase, meta
 
-    def _save_imgs(self, birefringence, phase, meta=None):
-        """
-        function to save images.
-        Makes sure file names do not overlap, i.e. nothing is overwritten.
+    # def _save_imgs(self, birefringence, phase, meta=None):
+    #     """
+    #     function to save images.
+    #     Makes sure file names do not overlap, i.e. nothing is overwritten.
 
-        Parameters
-        ----------
-        birefringence:      (nd-array) birefringence image(s)
-        phase:              (nd-array or None) phase image(s)
+    #     Parameters
+    #     ----------
+    #     birefringence:      (nd-array) birefringence image(s)
+    #     phase:              (nd-array or None) phase image(s)
 
-        Returns
-        -------
+    #     Returns
+    #     -------
 
-        """
-        prefix = self.calib_window.save_name
+    #     """
+    #     prefix = self.calib_window.save_name
 
-        name = (
-            f"ReconstructionSnap.zarr"
-            if not prefix
-            else f"{prefix}_ReconstructionSnap.zarr"
-        )
+    #     name = (
+    #         f"ReconstructionSnap.zarr"
+    #         if not prefix
+    #         else f"{prefix}_ReconstructionSnap.zarr"
+    #     )
 
-        with open_ome_zarr(
-            os.path.join(self.snap_dir, name),
-            layout="fov",
-            mode="w-",
-            channel_names=["Retardance", "Orientation", "BF", "Pol"],
-        ) as dataset:
-            if birefringence.ndim == 3:
-                birefringence = birefringence[:, np.newaxis]  # CYX -> CZYX
-            birefringence = birefringence[np.newaxis]  # CZYX -> TCZYX
-            dataset["0"] = birefringence
+    #     with open_ome_zarr(
+    #         os.path.join(self.snap_dir, name),
+    #         layout="fov",
+    #         mode="w-",
+    #         channel_names=["Retardance", "Orientation", "BF", "Pol"],
+    #     ) as dataset:
+    #         if birefringence.ndim == 3:
+    #             birefringence = birefringence[:, np.newaxis]  # CYX -> CZYX
+    #         birefringence = birefringence[np.newaxis]  # CZYX -> TCZYX
+    #         dataset["0"] = birefringence
 
-            if phase is not None:
-                dataset.append_channel(
-                    "Phase" + str(phase.ndim) + "D", resize_arrays=True
-                )
-                if phase.ndim == 2:
-                    phase = phase[np.newaxis]  # YX -> ZYX
-                dataset["0"][0, 4] = phase
+    #         if phase is not None:
+    #             dataset.append_channel(
+    #                 "Phase" + str(phase.ndim) + "D", resize_arrays=True
+    #             )
+    #             if phase.ndim == 2:
+    #                 phase = phase[np.newaxis]  # YX -> ZYX
+    #             dataset["0"][0, 4] = phase
 
-            dataset.zattrs["recOrder"] = meta
+    #         dataset.zattrs["recOrder"] = meta
 
-    def _load_bg(self, path, height, width):
-        """
-        # TODO: remove ROI for 1.0.0
+    # def _load_bg(self, path, height, width):
+    #     """
+    #     # TODO: remove ROI for 1.0.0
 
-        Load background and calibration metadata.
+    #     Load background and calibration metadata.
 
-        Parameters
-        ----------
-        path:           (str) path to the BG folder
-        height:         (int) height of BG image
-        width:          (int) widht of BG image
+    #     Parameters
+    #     ----------
+    #     path:           (str) path to the BG folder
+    #     height:         (int) height of BG image
+    #     width:          (int) widht of BG image
 
-        Returns
-        -------
+    #     Returns
+    #     -------
 
-        """
+    #     """
 
-        # TODO: Change to just accept ROI
-        try:
-            metadata_path = get_last_metadata_file(path)
-            metadata = MetadataReader(metadata_path)
-            roi = metadata.ROI
-        except:
-            roi = None
+    #     # TODO: Change to just accept ROI
+    #     try:
+    #         metadata_path = get_last_metadata_file(path)
+    #         metadata = MetadataReader(metadata_path)
+    #         roi = metadata.ROI
+    #     except:
+    #         roi = None
 
-        bg_data = load_bg(path, height, width, roi)
+    #     bg_data = load_bg(path, height, width, roi)
 
-        return bg_data
+    #     return bg_data
 
     def _reconstructor_changed(self):
         """
@@ -1134,10 +1285,10 @@ class PolarizationAcquisitionWorker(WorkerBase):
                         if not save_prefix
                         else f"{save_prefix}_RawPolDataSnap.zarr"
                     )
-                    out_path = os.path.join(self.snap_dir, name)
+                    self.latest_out_path = os.path.join(self.snap_dir, name)
                     converter = TIFFConverter(
                         os.path.join(dir_, prefix),
-                        out_path,
+                        self.latest_out_path,
                         data_type="ometiff",
                         grid_layout=False,
                         label_positions=False,
@@ -1151,376 +1302,376 @@ class PolarizationAcquisitionWorker(WorkerBase):
                 continue
 
 
-class ListeningWorker(WorkerBase):
-    """
-    Class to execute a birefringence/phase acquisition.  First step is to snap the images follow by a second
-    step of reconstructing those images.
-    """
+# class ListeningWorker(WorkerBase):
+#     """
+#     Class to execute a birefringence/phase acquisition.  First step is to snap the images follow by a second
+#     step of reconstructing those images.
+#     """
 
-    def __init__(self, calib_window, bg_data):
-        super().__init__(SignalsClass=ListeningSignals)
+#     def __init__(self, calib_window, bg_data):
+#         super().__init__(SignalsClass=ListeningSignals)
 
-        # Save current state of GUI window
-        self.calib_window = calib_window
+#         # Save current state of GUI window
+#         self.calib_window = calib_window
 
-        # Init properties
-        self.n_slices = None
-        self.n_channels = None
-        self.n_frames = None
-        self.n_pos = None
-        self.shape = None
-        self.dtype = None
-        self.root = None
-        self.prefix = None
-        self.store = None
-        self.save_directory = None
-        self.bg_data = bg_data
-        self.reconstructor = None
+#         # Init properties
+#         self.n_slices = None
+#         self.n_channels = None
+#         self.n_frames = None
+#         self.n_pos = None
+#         self.shape = None
+#         self.dtype = None
+#         self.root = None
+#         self.prefix = None
+#         self.store = None
+#         self.save_directory = None
+#         self.bg_data = bg_data
+#         self.reconstructor = None
 
-    def _check_abort(self):
-        if self.abort_requested:
-            self.aborted.emit()
-            raise TimeoutError("Stop Requested")
+#     def _check_abort(self):
+#         if self.abort_requested:
+#             self.aborted.emit()
+#             raise TimeoutError("Stop Requested")
 
-    def get_byte_offset(self, offsets, page):
-        """
-        Gets the byte offset from the tiff tag metadata.
+#     def get_byte_offset(self, offsets, page):
+#         """
+#         Gets the byte offset from the tiff tag metadata.
 
-        210 accounts for header data + page header data.
-        162 accounts page header data
+#         210 accounts for header data + page header data.
+#         162 accounts page header data
 
-        Parameters
-        ----------
-        offsets:             (dict) Offset dictionary list
-        page:               (int) Page to look at for the offset
+#         Parameters
+#         ----------
+#         offsets:             (dict) Offset dictionary list
+#         page:               (int) Page to look at for the offset
 
-        Returns
-        -------
-        byte offset:        (int) byte offset for the image array
+#         Returns
+#         -------
+#         byte offset:        (int) byte offset for the image array
 
-        """
+#         """
 
-        if page == 0:
-            array_offset = offsets[page] + 210
-        else:
-            array_offset = offsets[page] + 162
+#         if page == 0:
+#             array_offset = offsets[page] + 210
+#         else:
+#             array_offset = offsets[page] + 162
 
-        return array_offset
+#         return array_offset
 
-    def listen_for_images(
-        self, array, file, offsets, interval, dim3, dim2, dim1, dim0, dim_order
-    ):
-        """
+#     def listen_for_images(
+#         self, array, file, offsets, interval, dim3, dim2, dim1, dim0, dim_order
+#     ):
+#         """
 
-        Parameters
-        ----------
-        array:          (nd-array) numpy array of size (C, Z)
-        file:           (string) filepath corresponding to the desired tiff image
-        offsets:        (dict) dictionary of offsets corresponding to byte offsets of pixel data in tiff image
-        interval:       (int) time interval between timepoints in seconds
-        dim3:           (int) outermost dimension to value begin at
-        dim2:           (int) first-inner dimension value to begin at
-        dim1:           (int) second-inner dimension value to begin at
-        dim0:           (int) innermost dimension value to begin at
-        dim_order:      (int) 1, 2, 3, or 4 corresponding to the dimensionality ordering of the acquisition (MM-provided)
+#         Parameters
+#         ----------
+#         array:          (nd-array) numpy array of size (C, Z)
+#         file:           (string) filepath corresponding to the desired tiff image
+#         offsets:        (dict) dictionary of offsets corresponding to byte offsets of pixel data in tiff image
+#         interval:       (int) time interval between timepoints in seconds
+#         dim3:           (int) outermost dimension to value begin at
+#         dim2:           (int) first-inner dimension value to begin at
+#         dim1:           (int) second-inner dimension value to begin at
+#         dim0:           (int) innermost dimension value to begin at
+#         dim_order:      (int) 1, 2, 3, or 4 corresponding to the dimensionality ordering of the acquisition (MM-provided)
 
-        Returns
-        -------
-        array:                      (nd-array) partially filled array of size (C, Z) to continue filling in next iteration
-        index:                      (int) current page number at end of function
-        dim3:                       (int) dimension values corresponding to where the next iteration should begin
-        dim2:                       (int) dimension values corresponding to where the next iteration should begin
-        dim1:                       (int) dimension values corresponding to where the next iteration should begin
-        dim0:                       (int) dimension values corresponding to where the next iteration should begin
+#         Returns
+#         -------
+#         array:                      (nd-array) partially filled array of size (C, Z) to continue filling in next iteration
+#         index:                      (int) current page number at end of function
+#         dim3:                       (int) dimension values corresponding to where the next iteration should begin
+#         dim2:                       (int) dimension values corresponding to where the next iteration should begin
+#         dim1:                       (int) dimension values corresponding to where the next iteration should begin
+#         dim0:                       (int) dimension values corresponding to where the next iteration should begin
 
-        """
+#         """
 
-        # Order dimensions that we will loop through in order to match the acquisition
-        if dim_order == 0:
-            dims = [
-                [dim3, self.n_frames],
-                [dim2, self.n_pos],
-                [dim1, self.n_slices],
-                [dim0, self.n_channels],
-            ]
-            channel_dim = 0
-        elif dim_order == 1:
-            dims = [
-                [dim3, self.n_frames],
-                [dim2, self.n_pos],
-                [dim1, self.n_channels],
-                [dim0, self.n_slices],
-            ]
-            channel_dim = 1
-        elif dim_order == 2:
-            dims = [
-                [dim3, self.n_pos],
-                [dim2, self.n_frames],
-                [dim1, self.n_slices],
-                [dim0, self.n_channels],
-            ]
-            channel_dim = 0
-        else:
-            dims = [
-                [dim3, self.n_pos],
-                [dim2, self.n_frames],
-                [dim1, self.n_channels],
-                [dim0, self.n_slices],
-            ]
-            channel_dim = 1
+#         # Order dimensions that we will loop through in order to match the acquisition
+#         if dim_order == 0:
+#             dims = [
+#                 [dim3, self.n_frames],
+#                 [dim2, self.n_pos],
+#                 [dim1, self.n_slices],
+#                 [dim0, self.n_channels],
+#             ]
+#             channel_dim = 0
+#         elif dim_order == 1:
+#             dims = [
+#                 [dim3, self.n_frames],
+#                 [dim2, self.n_pos],
+#                 [dim1, self.n_channels],
+#                 [dim0, self.n_slices],
+#             ]
+#             channel_dim = 1
+#         elif dim_order == 2:
+#             dims = [
+#                 [dim3, self.n_pos],
+#                 [dim2, self.n_frames],
+#                 [dim1, self.n_slices],
+#                 [dim0, self.n_channels],
+#             ]
+#             channel_dim = 0
+#         else:
+#             dims = [
+#                 [dim3, self.n_pos],
+#                 [dim2, self.n_frames],
+#                 [dim1, self.n_channels],
+#                 [dim0, self.n_slices],
+#             ]
+#             channel_dim = 1
 
-        # Loop through dimensions in the order they are acquired
-        idx = 0
-        for dim3 in range(dims[0][0], dims[0][1]):
-            for dim2 in range(dims[1][0], dims[1][1]):
-                for dim1 in range(dims[2][0], dims[2][1]):
-                    for dim0 in range(dims[3][0], dims[3][1]):
-                        # GET OFFSET AND WAIT
-                        if idx > 0:
-                            try:
-                                offset = self.get_byte_offset(offsets, idx)
-                            except IndexError:
-                                # NEED TO STOP BECAUSE RAN OUT OF PAGES OR REACHED END OF ACQ
-                                return array, idx, dim3, dim2, dim1, dim0
+#         # Loop through dimensions in the order they are acquired
+#         idx = 0
+#         for dim3 in range(dims[0][0], dims[0][1]):
+#             for dim2 in range(dims[1][0], dims[1][1]):
+#                 for dim1 in range(dims[2][0], dims[2][1]):
+#                     for dim0 in range(dims[3][0], dims[3][1]):
+#                         # GET OFFSET AND WAIT
+#                         if idx > 0:
+#                             try:
+#                                 offset = self.get_byte_offset(offsets, idx)
+#                             except IndexError:
+#                                 # NEED TO STOP BECAUSE RAN OUT OF PAGES OR REACHED END OF ACQ
+#                                 return array, idx, dim3, dim2, dim1, dim0
 
-                            # Checks if the offset in metadata is 0, but technically self.get_byte_offset() adds
-                            # 162 to every offset to account for tiff file header bytes
-                            while offset == 162:
-                                self._check_abort()
-                                tf = tiff.TiffFile(file)
-                                time.sleep(interval)
-                                offsets = tf.micromanager_metadata["IndexMap"][
-                                    "Offset"
-                                ]
-                                tf.close()
-                                offset = self.get_byte_offset(offsets, idx)
-                        else:
-                            offset = self.get_byte_offset(offsets, idx)
+#                             # Checks if the offset in metadata is 0, but technically self.get_byte_offset() adds
+#                             # 162 to every offset to account for tiff file header bytes
+#                             while offset == 162:
+#                                 self._check_abort()
+#                                 tf = tiff.TiffFile(file)
+#                                 time.sleep(interval)
+#                                 offsets = tf.micromanager_metadata["IndexMap"][
+#                                     "Offset"
+#                                 ]
+#                                 tf.close()
+#                                 offset = self.get_byte_offset(offsets, idx)
+#                         else:
+#                             offset = self.get_byte_offset(offsets, idx)
 
-                        if idx < (
-                            self.n_slices
-                            * self.n_channels
-                            * self.n_frames
-                            * self.n_pos
-                        ):
-                            # Assign dimensions based off acquisition order to correctly add image to array
-                            if dim_order == 0:
-                                t, p, c, z = dim3, dim2, dim0, dim1
-                            elif dim_order == 1:
-                                t, p, c, z = dim3, dim2, dim1, dim0
-                            elif dim_order == 2:
-                                t, p, c, z = dim2, dim3, dim0, dim1
-                            else:
-                                t, p, c, z = dim2, dim3, dim1, dim0
+#                         if idx < (
+#                             self.n_slices
+#                             * self.n_channels
+#                             * self.n_frames
+#                             * self.n_pos
+#                         ):
+#                             # Assign dimensions based off acquisition order to correctly add image to array
+#                             if dim_order == 0:
+#                                 t, p, c, z = dim3, dim2, dim0, dim1
+#                             elif dim_order == 1:
+#                                 t, p, c, z = dim3, dim2, dim1, dim0
+#                             elif dim_order == 2:
+#                                 t, p, c, z = dim2, dim3, dim0, dim1
+#                             else:
+#                                 t, p, c, z = dim2, dim3, dim1, dim0
 
-                            self._check_abort()
+#                             self._check_abort()
 
-                            # Add Image to array
-                            img = np.memmap(
-                                file,
-                                dtype=self.dtype,
-                                mode="r",
-                                offset=offset,
-                                shape=self.shape,
-                            )
-                            array[c, z] = img
+#                             # Add Image to array
+#                             img = np.memmap(
+#                                 file,
+#                                 dtype=self.dtype,
+#                                 mode="r",
+#                                 offset=offset,
+#                                 shape=self.shape,
+#                             )
+#                             array[c, z] = img
 
-                            # If Channel first, compute birefringence here
-                            if (
-                                channel_dim == 0
-                                and dim0 == self.n_channels - 1
-                            ):
-                                self._check_abort()
+#                             # If Channel first, compute birefringence here
+#                             if (
+#                                 channel_dim == 0
+#                                 and dim0 == self.n_channels - 1
+#                             ):
+#                                 self._check_abort()
 
-                                # Compute birefringence
-                                self.compute_and_save(array[:, z], p, t, z)
+#                                 # Compute birefringence
+#                                 self.compute_and_save(array[:, z], p, t, z)
 
-                            idx += 1
+#                             idx += 1
 
-                    # Reset Range to 0 to account for starting this function in middle of a dimension
-                    if idx < (
-                        self.n_slices
-                        * self.n_channels
-                        * self.n_frames
-                        * self.n_pos
-                    ):
-                        dims[2][0] = 0
-                        dims[3][0] = 0
+#                     # Reset Range to 0 to account for starting this function in middle of a dimension
+#                     if idx < (
+#                         self.n_slices
+#                         * self.n_channels
+#                         * self.n_frames
+#                         * self.n_pos
+#                     ):
+#                         dims[2][0] = 0
+#                         dims[3][0] = 0
 
-                    # If z-first, compute the birefringence here
-                    if channel_dim == 1 and dim1 == self.n_channels - 1:
-                        # Assign dimensions based off acquisition order to correctly add image to array
-                        if dim_order == 0:
-                            t, p, c, z = dim3, dim2, dim0, dim1
-                        elif dim_order == 1:
-                            t, p, c, z = dim3, dim2, dim1, dim0
-                        elif dim_order == 2:
-                            t, p, c, z = dim2, dim3, dim0, dim1
-                        else:
-                            t, p, c, z = dim2, dim3, dim1, dim0
+#                     # If z-first, compute the birefringence here
+#                     if channel_dim == 1 and dim1 == self.n_channels - 1:
+#                         # Assign dimensions based off acquisition order to correctly add image to array
+#                         if dim_order == 0:
+#                             t, p, c, z = dim3, dim2, dim0, dim1
+#                         elif dim_order == 1:
+#                             t, p, c, z = dim3, dim2, dim1, dim0
+#                         elif dim_order == 2:
+#                             t, p, c, z = dim2, dim3, dim0, dim1
+#                         else:
+#                             t, p, c, z = dim2, dim3, dim1, dim0
 
-                        self._check_abort()
-                        self.compute_and_save(array, p, t, dim0)
-                    else:
-                        continue
+#                         self._check_abort()
+#                         self.compute_and_save(array, p, t, dim0)
+#                     else:
+#                         continue
 
-                # Reset range to 0 to account for starting this function in the middle of a dimension
-                if idx < (
-                    self.n_slices
-                    * self.n_channels
-                    * self.n_frames
-                    * self.n_pos
-                ):
-                    dims[1][0] = 0
+#                 # Reset range to 0 to account for starting this function in the middle of a dimension
+#                 if idx < (
+#                     self.n_slices
+#                     * self.n_channels
+#                     * self.n_frames
+#                     * self.n_pos
+#                 ):
+#                     dims[1][0] = 0
 
-        # Return at the end of the acquisition
-        return array, idx, dim3, dim2, dim1, dim0
+#         # Return at the end of the acquisition
+#         return array, idx, dim3, dim2, dim1, dim0
 
-    def compute_and_save(self, array, p, t, z):
-        if self.n_slices == 1:
-            array = array[:, 0]
+#     def compute_and_save(self, array, p, t, z):
+#         if self.n_slices == 1:
+#             array = array[:, 0]
 
-        birefringence = self.reconstructor.reconstruct(array)
+#         birefringence = self.reconstructor.reconstruct(array)
 
-        # If the napari layer doesn't exist yet, create the zarr store to emit to napari
-        if self.prefix not in self.calib_window.viewer.layers:
-            self.store = zarr.open(
-                os.path.join(self.root, self.prefix + ".zarr")
-            )
-            self.store.zeros(
-                name="Birefringence",
-                shape=(
-                    self.n_pos,
-                    self.n_frames,
-                    2,
-                    self.n_slices,
-                    self.shape[0],
-                    self.shape[1],
-                ),
-                chunks=(1, 1, 1, 1, self.shape[0], self.shape[1]),
-                overwrite=True,
-            )
+#         # If the napari layer doesn't exist yet, create the zarr store to emit to napari
+#         if self.prefix not in self.calib_window.viewer.layers:
+#             self.store = zarr.open(
+#                 os.path.join(self.root, self.prefix + ".zarr")
+#             )
+#             self.store.zeros(
+#                 name="Birefringence",
+#                 shape=(
+#                     self.n_pos,
+#                     self.n_frames,
+#                     2,
+#                     self.n_slices,
+#                     self.shape[0],
+#                     self.shape[1],
+#                 ),
+#                 chunks=(1, 1, 1, 1, self.shape[0], self.shape[1]),
+#                 overwrite=True,
+#             )
 
-            # Add data and send out the store.  Once the store has been emitted, we can add data to the store
-            # without needing to emit the store again (thanks to napari's handling of zarr datasets)
-            if len(birefringence.shape) == 4:
-                self.store["Birefringence"][p, t] = birefringence
-            else:
-                self.store["Birefringence"][p, t, :, z] = birefringence
+#             # Add data and send out the store.  Once the store has been emitted, we can add data to the store
+#             # without needing to emit the store again (thanks to napari's handling of zarr datasets)
+#             if len(birefringence.shape) == 4:
+#                 self.store["Birefringence"][p, t] = birefringence
+#             else:
+#                 self.store["Birefringence"][p, t, :, z] = birefringence
 
-            self.store_emitter.emit(self.store)
+#             self.store_emitter.emit(self.store)
 
-        else:
-            if len(birefringence.shape) == 4:
-                self.store["Birefringence"][p, t] = birefringence
-            else:
-                self.store["Birefringence"][p, t, :, z] = birefringence
+#         else:
+#             if len(birefringence.shape) == 4:
+#                 self.store["Birefringence"][p, t] = birefringence
+#             else:
+#                 self.store["Birefringence"][p, t, :, z] = birefringence
 
-        # Emit the current dimensions so that we can update the napari dimension slider
-        self.dim_emitter.emit((p, t, z))
+#         # Emit the current dimensions so that we can update the napari dimension slider
+#         self.dim_emitter.emit((p, t, z))
 
-    def work(self):
-        acq_man = self.calib_window.mm.acquisitions()
+#     def work(self):
+#         acq_man = self.calib_window.mm.acquisitions()
 
-        while not acq_man.isAcquisitionRunning():
-            pass
+#         while not acq_man.isAcquisitionRunning():
+#             pass
 
-        time.sleep(1)
+#         time.sleep(1)
 
-        # Get all of the dataset dimensions, settings
-        s = acq_man.getAcquisitionSettings()
-        self.root = s.root()
-        self.prefix = s.prefix()
-        self.n_frames, self.interval = (
-            (s.numFrames(), s.intervalMs() / 1000) if s.useFrames() else (1, 1)
-        )
-        self.n_channels = s.channels().size() if s.useChannels() else 1
-        self.n_slices = s.slices().size() if s.useChannels() else 1
-        self.n_pos = (
-            1
-            if not s.usePositionList()
-            else self.calib_window.mm.getPositionListManager()
-            .getPositionList()
-            .getNumberOfPositions()
-        )
-        dim_order = s.acqOrderMode()
+#         # Get all of the dataset dimensions, settings
+#         s = acq_man.getAcquisitionSettings()
+#         self.root = s.root()
+#         self.prefix = s.prefix()
+#         self.n_frames, self.interval = (
+#             (s.numFrames(), s.intervalMs() / 1000) if s.useFrames() else (1, 1)
+#         )
+#         self.n_channels = s.channels().size() if s.useChannels() else 1
+#         self.n_slices = s.slices().size() if s.useChannels() else 1
+#         self.n_pos = (
+#             1
+#             if not s.usePositionList()
+#             else self.calib_window.mm.getPositionListManager()
+#             .getPositionList()
+#             .getNumberOfPositions()
+#         )
+#         dim_order = s.acqOrderMode()
 
-        # Get File Path corresponding to current dataset
-        path = os.path.join(self.root, self.prefix)
-        files = [fn for fn in glob.glob(path + "*") if ".zarr" not in fn]
-        index = max([int(x.strip(path + "_")) for x in files])
+#         # Get File Path corresponding to current dataset
+#         path = os.path.join(self.root, self.prefix)
+#         files = [fn for fn in glob.glob(path + "*") if ".zarr" not in fn]
+#         index = max([int(x.strip(path + "_")) for x in files])
 
-        self.prefix = self.prefix + f"_{index}"
-        full_path = os.path.join(self.root, self.prefix)
-        first_file_path = os.path.join(
-            full_path, self.prefix + "_MMStack.ome.tif"
-        )
+#         self.prefix = self.prefix + f"_{index}"
+#         full_path = os.path.join(self.root, self.prefix)
+#         first_file_path = os.path.join(
+#             full_path, self.prefix + "_MMStack.ome.tif"
+#         )
 
-        file = tiff.TiffFile(first_file_path)
-        file_path = first_file_path
-        self.shape = (
-            file.micromanager_metadata["Summary"]["Height"],
-            file.micromanager_metadata["Summary"]["Width"],
-        )
-        self.dtype = file.pages[0].dtype
-        offsets = file.micromanager_metadata["IndexMap"]["Offset"]
-        file.close()
+#         file = tiff.TiffFile(first_file_path)
+#         file_path = first_file_path
+#         self.shape = (
+#             file.micromanager_metadata["Summary"]["Height"],
+#             file.micromanager_metadata["Summary"]["Width"],
+#         )
+#         self.dtype = file.pages[0].dtype
+#         offsets = file.micromanager_metadata["IndexMap"]["Offset"]
+#         file.close()
 
-        self._check_abort()
+#         self._check_abort()
 
-        # Init Reconstruction Class
-        self.reconstructor = QLIPPBirefringenceCompute(
-            self.shape,
-            self.calib_window.calib_scheme,
-            self.calib_window.wavelength,
-            self.calib_window.swing,
-            self.n_slices,
-            self.calib_window.bg_option,
-            self.bg_data,
-        )
+#         # Init Reconstruction Class
+#         self.reconstructor = QLIPPBirefringenceCompute(
+#             self.shape,
+#             self.calib_window.calib_scheme,
+#             self.calib_window.wavelength,
+#             self.calib_window.swing,
+#             self.n_slices,
+#             self.calib_window.bg_option,
+#             self.bg_data,
+#         )
 
-        self._check_abort()
+#         self._check_abort()
 
-        # initialize dimensions / array for the loop
-        idx, dim3, dim2, dim1, dim0 = 0, 0, 0, 0, 0
-        array = np.zeros(
-            (self.n_channels, self.n_slices, self.shape[0], self.shape[1])
-        )
-        file_count = 0
-        total_idx = 0
+#         # initialize dimensions / array for the loop
+#         idx, dim3, dim2, dim1, dim0 = 0, 0, 0, 0, 0
+#         array = np.zeros(
+#             (self.n_channels, self.n_slices, self.shape[0], self.shape[1])
+#         )
+#         file_count = 0
+#         total_idx = 0
 
-        # Run until the function has collected the totality of the data
-        while total_idx < (
-            self.n_slices * self.n_channels * self.n_frames * self.n_pos
-        ):
-            self._check_abort()
+#         # Run until the function has collected the totality of the data
+#         while total_idx < (
+#             self.n_slices * self.n_channels * self.n_frames * self.n_pos
+#         ):
+#             self._check_abort()
 
-            # this will loop through reading images in a single file as it's being written
-            # when it has successfully loaded all of the images from the file, it'll move on to the next
-            array, idx, dim3, dim2, dim1, dim0 = self.listen_for_images(
-                array,
-                file_path,
-                offsets,
-                self.interval,
-                dim3,
-                dim2,
-                dim1,
-                dim0,
-                dim_order,
-            )
+#             # this will loop through reading images in a single file as it's being written
+#             # when it has successfully loaded all of the images from the file, it'll move on to the next
+#             array, idx, dim3, dim2, dim1, dim0 = self.listen_for_images(
+#                 array,
+#                 file_path,
+#                 offsets,
+#                 self.interval,
+#                 dim3,
+#                 dim2,
+#                 dim1,
+#                 dim0,
+#                 dim_order,
+#             )
 
-            total_idx += idx
+#             total_idx += idx
 
-            # If acquisition is not finished, grab the next file and listen for images
-            if (
-                total_idx
-                != self.n_slices * self.n_channels * self.n_frames * self.n_pos
-            ):
-                time.sleep(1)
-                file_count += 1
-                file_path = os.path.join(
-                    full_path, self.prefix + f"_MMStack_{file_count}.ome.tif"
-                )
-                file = tiff.TiffFile(file_path)
-                offsets = file.micromanager_metadata["IndexMap"]["Offset"]
-                file.close()
+#             # If acquisition is not finished, grab the next file and listen for images
+#             if (
+#                 total_idx
+#                 != self.n_slices * self.n_channels * self.n_frames * self.n_pos
+#             ):
+#                 time.sleep(1)
+#                 file_count += 1
+#                 file_path = os.path.join(
+#                     full_path, self.prefix + f"_MMStack_{file_count}.ome.tif"
+#                 )
+#                 file = tiff.TiffFile(file_path)
+#                 offsets = file.micromanager_metadata["IndexMap"]["Offset"]
+#                 file.close()

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -1,7 +1,12 @@
 import click
+from recOrder.cli.parsing import config_path_option, output_dataset_options
 
 
 @click.command()
-def apply_inverse_transfer_function():
+@config_path_option()
+@output_dataset_options()
+def apply_inverse_transfer_function(
+    transfer_function_path, config_path, input_path, output_path
+):
     "Invert and apply a transfer function"
     return NotImplementedError

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -1,0 +1,6 @@
+import click
+
+
+@click.command()
+def apply_inverse_transfer_function():
+    return NotImplementedError

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -1,12 +1,371 @@
 import click
-from recOrder.cli.parsing import config_path_option, output_dataset_options
+import numpy as np
+import torch
+import yaml
+from iohub import open_ome_zarr
+from recOrder.cli.printing import echo_headline, echo_settings
+from recOrder.cli.settings import (
+    TransferFunctionSettings,
+    ApplyInverseSettings,
+)
+from recOrder.cli.parsing import (
+    input_data_path_argument,
+    config_path_option,
+    output_dataset_options,
+)
+from recOrder.io import utils
+from waveorder.models import (
+    inplane_anisotropic_thin_pol3d,
+    isotropic_thin_3d,
+    phase_thick_3d,
+)
+
+
+def _check_shape_consistency(settings, data_shape):
+    c_shape = data_shape[1]
+    zyx_shape = data_shape[2:]
+
+    # Check zyx dimensions for phase
+    if settings.universal_settings.reconstruct_phase:
+        if settings.phase_transfer_function_settings.zyx_shape != list(
+            zyx_shape
+        ):
+            raise (
+                ValueError(
+                    f"Transfer function shape = {settings.phase_transfer_function_settings.zyx_shape} is not the same as the data shape = {zyx_shape}. Consider regenerating the transfer function."
+                )
+            )
+
+    # Check c dimensions for birefringence
+    if settings.universal_settings.reconstruct_birefringence:
+        if (
+            int(settings.birefringence_transfer_function_settings.scheme[0])
+            != c_shape
+        ):
+            raise (
+                ValueError(
+                    f"scheme = {settings.birefringence_transfer_function_settings.scheme} is not the same as the data's channel shape = {c_shape}. Consider regenerating the transfer function or finding compatible data."
+                )
+            )
+
+
+def _check_background_consistency(background_shape, data_shape):
+    data_cyx_shape = (data_shape[1],) + data_shape[3:]
+    if background_shape != data_cyx_shape:
+        raise ValueError(
+            f"Background shape {background_shape} does not match data shape {data_cyx_shape}"
+        )
 
 
 @click.command()
+@input_data_path_argument()
+@click.argument(
+    "transfer_function_path",
+    type=click.Path(exists=True),
+)
 @config_path_option()
-@output_dataset_options()
+@output_dataset_options(default="./reconstruction.zarr")
 def apply_inverse_transfer_function(
-    transfer_function_path, config_path, input_path, output_path
+    input_data_path, transfer_function_path, config_path, output_path
 ):
     "Invert and apply a transfer function"
-    return NotImplementedError
+    echo_headline("Starting reconstruction...")
+
+    # Load datasets
+    transfer_function_dataset = open_ome_zarr(transfer_function_path)
+    input_dataset = open_ome_zarr(input_data_path)
+
+    # Load config file
+    if config_path is None:
+        inverse_settings = ApplyInverseSettings()
+    else:
+        with open(config_path) as file:
+            raw_settings = yaml.safe_load(file)
+        inverse_settings = ApplyInverseSettings(**raw_settings)
+
+    # Load transfer settings
+    settings = TransferFunctionSettings(
+        **transfer_function_dataset.zattrs["transfer_function_settings"]
+    )
+
+    # Load dataset shape and check for consistency
+    _check_shape_consistency(
+        settings, input_dataset.data.shape  # only loads a single position "0"
+    )
+    t_shape = input_dataset.data.shape[0]
+
+    # Simplify important settings names
+    recon_biref = settings.universal_settings.reconstruct_birefringence
+    recon_phase = settings.universal_settings.reconstruct_phase
+    recon_dim = settings.universal_settings.reconstruction_dimension
+    wavelength = settings.universal_settings.wavelength_illumination
+
+    # Prepare output dataset
+    channel_names = []
+    if recon_biref:
+        channel_names.append("Retardance")
+        channel_names.append("Orientation")
+        channel_names.append("BF")
+        channel_names.append("Pol")
+    if recon_phase:
+        if recon_dim == 2:
+            channel_names.append("Phase2D")
+        elif recon_dim == 3:
+            channel_names.append("Phase3D")
+
+    if recon_dim == 2:
+        output_z_shape = 1
+    elif recon_dim == 3:
+        output_z_shape = input_dataset.data.shape[2]
+
+    output_shape = (
+        t_shape,
+        len(channel_names),
+        output_z_shape,
+    ) + input_dataset.data.shape[3:]
+
+    # Create output dataset
+    output_dataset = open_ome_zarr(
+        output_path, layout="fov", mode="w", channel_names=channel_names
+    )
+    output_array = output_dataset.create_zeros(
+        name="0",
+        shape=output_shape,
+        dtype=np.float32,
+        chunks=(
+            1,
+            1,
+            1,
+        )
+        + input_dataset.data.shape[3:],  # chunk by YX
+    )
+
+    # Load data
+    tczyx_data = torch.tensor(input_dataset.data, dtype=torch.float32)
+
+    # Prepare background dataset
+    if recon_biref:
+        biref_inverse_dict = (
+            inverse_settings.birefringence_apply_inverse_settings.dict()
+        )
+
+        # Resolve background path into array
+        background_path = biref_inverse_dict["background_path"]
+        biref_inverse_dict.pop("background_path")
+        if background_path is not None:
+            cyx_no_sample_data = utils.new_load_background(background_path)
+            _check_background_consistency(
+                cyx_no_sample_data.shape, input_dataset.data.shape
+            )
+        else:
+            cyx_no_sample_data = None
+
+    # Main reconstruction logic
+    # Six different cases [2, 3] x [biref only, phase only, both]
+
+    # [biref only] [2 or 3]
+    if recon_biref and (not recon_phase):
+        echo_headline("Reconstructing birefringence with settings:")
+        echo_settings(inverse_settings.birefringence_apply_inverse_settings)
+        echo_headline("Reconstructing birefringence...")
+
+        # Load transfer function
+        intensity_to_stokes_matrix = torch.tensor(
+            transfer_function_dataset["intensity_to_stokes_matrix"][0, 0, 0]
+        )
+
+        for time_index in range(t_shape):
+            # Apply
+            reconstructed_parameters = (
+                inplane_anisotropic_thin_pol3d.apply_inverse_transfer_function(
+                    tczyx_data[time_index],
+                    intensity_to_stokes_matrix,
+                    wavelength,
+                    cyx_no_sample_data,
+                    project_stokes_to_2d=False,
+                    **biref_inverse_dict,
+                )
+            )
+            # Save
+            for param_index, parameter in enumerate(reconstructed_parameters):
+                output_array[time_index, param_index] = parameter
+
+    # [phase only]
+    if recon_phase and (not recon_biref):
+        echo_headline("Reconstructing phase with settings:")
+        echo_settings(inverse_settings.phase_apply_inverse_settings)
+        echo_headline("Reconstructing phase...")
+
+        # check data shapes
+        if input_dataset.data.shape[1] != 1:
+            raise ValueError(
+                "You have requested a phase-only reconstruction, but the input dataset has more than one channel."
+            )
+
+        # [phase only, 2]
+        if recon_dim == 2:
+            # Load transfer functions
+            absorption_transfer_function = torch.tensor(
+                transfer_function_dataset["absorption_transfer_function"][0, 0]
+            )
+            phase_transfer_function = torch.tensor(
+                transfer_function_dataset["phase_transfer_function"][0, 0]
+            )
+
+            for time_index in range(t_shape):
+                # Apply
+                (
+                    _,
+                    yx_phase,
+                ) = isotropic_thin_3d.apply_inverse_transfer_function(
+                    tczyx_data[time_index, 0],
+                    absorption_transfer_function,
+                    phase_transfer_function,
+                    method=inverse_settings.phase_apply_inverse_settings.reconstruction_algorithm,
+                )
+
+                # Save
+                output_array[time_index, -1, 0] = yx_phase
+
+        # [phase only, 3]
+        elif recon_dim == 3:
+            # Load transfer functions
+            real_potential_transfer_function = torch.tensor(
+                transfer_function_dataset["real_potential_transfer_function"][
+                    0, 0
+                ]
+            )
+            imaginary_potential_transfer_function = torch.tensor(
+                transfer_function_dataset[
+                    "imaginary_potential_transfer_function"
+                ][0, 0]
+            )
+
+            # Apply
+            for time_index in range(t_shape):
+                zyx_phase = phase_thick_3d.apply_inverse_transfer_function(
+                    tczyx_data[time_index, 0],
+                    real_potential_transfer_function,
+                    imaginary_potential_transfer_function,
+                    z_padding=settings.phase_transfer_function_settings.z_padding,
+                    z_pixel_size=settings.phase_transfer_function_settings.z_pixel_size,
+                    illumination_wavelength=wavelength,
+                )
+                # Save
+                output_array[time_index, -1] = zyx_phase
+
+    # [biref and phase]
+    if recon_biref and recon_phase:
+        echo_headline("Reconstructing phase with settings:")
+        echo_settings(inverse_settings.phase_apply_inverse_settings)
+        echo_headline("Reconstructing birefringence with settings:")
+        echo_settings(inverse_settings.birefringence_apply_inverse_settings)
+        echo_headline("Reconstructing...")
+
+        # Load birefringence transfer function
+        intensity_to_stokes_matrix = torch.tensor(
+            transfer_function_dataset["intensity_to_stokes_matrix"][0, 0, 0]
+        )
+
+        # [biref and phase, 2]
+        if recon_dim == 2:
+            # Load phase transfer functions
+            absorption_transfer_function = torch.tensor(
+                transfer_function_dataset["absorption_transfer_function"][0, 0]
+            )
+            phase_transfer_function = torch.tensor(
+                transfer_function_dataset["phase_transfer_function"][0, 0]
+            )
+
+            for time_index in range(t_shape):
+                # Apply
+                reconstructed_parameters_2d = inplane_anisotropic_thin_pol3d.apply_inverse_transfer_function(
+                    tczyx_data[time_index],
+                    intensity_to_stokes_matrix,
+                    wavelength,
+                    cyx_no_sample_data,
+                    project_stokes_to_2d=True,
+                    **biref_inverse_dict,
+                )
+
+                reconstructed_parameters_3d = inplane_anisotropic_thin_pol3d.apply_inverse_transfer_function(
+                    tczyx_data[time_index],
+                    intensity_to_stokes_matrix,
+                    wavelength,
+                    cyx_no_sample_data,
+                    project_stokes_to_2d=False,
+                    **biref_inverse_dict,
+                )
+
+                brightfield_3d = reconstructed_parameters_3d[2]
+
+                (
+                    _,
+                    yx_phase,
+                ) = isotropic_thin_3d.apply_inverse_transfer_function(
+                    brightfield_3d,
+                    absorption_transfer_function,
+                    phase_transfer_function,
+                    method=inverse_settings.phase_apply_inverse_settings.reconstruction_algorithm,
+                )
+
+                # Save
+                for param_index, parameter in enumerate(
+                    reconstructed_parameters_2d
+                ):
+                    output_array[time_index, param_index] = parameter
+                output_array[time_index, -1, 0] = yx_phase
+
+        # [biref and phase, 3]
+        elif recon_dim == 3:
+            # Load phase transfer functions
+            intensity_to_stokes_matrix = torch.tensor(
+                transfer_function_dataset["intensity_to_stokes_matrix"][
+                    0, 0, 0
+                ]
+            )
+            # Load transfer functions
+            real_potential_transfer_function = torch.tensor(
+                transfer_function_dataset["real_potential_transfer_function"][
+                    0, 0
+                ]
+            )
+            imaginary_potential_transfer_function = torch.tensor(
+                transfer_function_dataset[
+                    "imaginary_potential_transfer_function"
+                ][0, 0]
+            )
+
+            # Apply
+            for time_index in range(t_shape):
+                reconstructed_parameters_3d = inplane_anisotropic_thin_pol3d.apply_inverse_transfer_function(
+                    tczyx_data[time_index],
+                    intensity_to_stokes_matrix,
+                    wavelength,
+                    cyx_no_sample_data,
+                    project_stokes_to_2d=False,
+                    **biref_inverse_dict,
+                )
+
+                zyx_phase = phase_thick_3d.apply_inverse_transfer_function(
+                    tczyx_data[time_index, 0],
+                    real_potential_transfer_function,
+                    imaginary_potential_transfer_function,
+                    z_padding=settings.phase_transfer_function_settings.z_padding,
+                    z_pixel_size=settings.phase_transfer_function_settings.z_pixel_size,
+                    illumination_wavelength=wavelength,
+                )
+                # Save
+                for param_index, parameter in enumerate(
+                    reconstructed_parameters_3d
+                ):
+                    output_array[time_index, param_index] = parameter
+                output_array[time_index, -1] = zyx_phase
+
+    output_dataset.zattrs["transfer_function_settings"] = settings.dict()
+    output_dataset.zattrs["apply_inverse_settings"] = inverse_settings.dict()
+
+    echo_headline(f"Closing {output_path}\n")
+    output_dataset.close()
+    transfer_function_dataset.close()
+    input_dataset.close()

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -3,4 +3,5 @@ import click
 
 @click.command()
 def apply_inverse_transfer_function():
+    "Invert and apply a transfer function"
     return NotImplementedError

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -57,18 +57,9 @@ def _check_background_consistency(background_shape, data_shape):
         )
 
 
-@click.command()
-@input_data_path_argument()
-@click.argument(
-    "transfer_function_path",
-    type=click.Path(exists=True),
-)
-@config_path_option()
-@output_dataset_options(default="./reconstruction.zarr")
-def apply_inverse_transfer_function(
+def apply_inverse_transfer_function_cli(
     input_data_path, transfer_function_path, config_path, output_path
 ):
-    "Invert and apply a transfer function"
     echo_headline("Starting reconstruction...")
 
     # Load datasets
@@ -369,3 +360,24 @@ def apply_inverse_transfer_function(
     output_dataset.close()
     transfer_function_dataset.close()
     input_dataset.close()
+
+    echo_headline(
+        f"Recreate this reconstruction with:\n>> recorder apply-inverse-transfer-function {input_data_path} {transfer_function_path} -c {config_path} -o {output_path}"
+    )
+
+
+@click.command()
+@input_data_path_argument()
+@click.argument(
+    "transfer_function_path",
+    type=click.Path(exists=True),
+)
+@config_path_option()
+@output_dataset_options(default="./reconstruction.zarr")
+def apply_inverse_transfer_function(
+    input_data_path, transfer_function_path, config_path, output_path
+):
+    "Invert and apply a transfer function"
+    apply_inverse_transfer_function_cli(
+        input_data_path, transfer_function_path, config_path, output_path
+    )

--- a/recOrder/cli/compute_transfer_function.py
+++ b/recOrder/cli/compute_transfer_function.py
@@ -1,0 +1,6 @@
+import click
+
+
+@click.command()
+def compute_transfer_function():
+    return NotImplementedError

--- a/recOrder/cli/compute_transfer_function.py
+++ b/recOrder/cli/compute_transfer_function.py
@@ -3,4 +3,5 @@ import click
 
 @click.command()
 def compute_transfer_function():
+    "Compute a transfer function from configuration"
     return NotImplementedError

--- a/recOrder/cli/compute_transfer_function.py
+++ b/recOrder/cli/compute_transfer_function.py
@@ -12,12 +12,7 @@ from waveorder.models import (
 )
 
 
-@click.command()
-@config_path_option()
-@output_dataset_options(default="./transfer-function.zarr")
-def compute_transfer_function(config_path, output_path):
-    "Compute a transfer function from a configuration file"
-
+def compute_transfer_function_cli(config_path, output_path):
     # Load config file
     if config_path is None:
         settings = TransferFunctionSettings()
@@ -43,6 +38,7 @@ def compute_transfer_function(config_path, output_path):
             "Generating birefringence transfer function with settings:"
         )
         echo_settings(settings.birefringence_transfer_function_settings)
+
         # Calculate transfer functions
         intensity_to_stokes_matrix = (
             inplane_anisotropic_thin_pol3d.calculate_transfer_function(
@@ -114,3 +110,15 @@ def compute_transfer_function(config_path, output_path):
 
     echo_headline(f"Closing {output_path}\n")
     dataset.close()
+
+    echo_headline(
+        f"Recreate this transfer function with:\n>> recorder compute-transfer-function {config_path} -o {output_path}"
+    )
+
+
+@click.command()
+@config_path_option()
+@output_dataset_options(default="./transfer-function.zarr")
+def compute_transfer_function(config_path, output_path):
+    "Compute a transfer function from a configuration file"
+    compute_transfer_function_cli(config_path, output_path)

--- a/recOrder/cli/compute_transfer_function.py
+++ b/recOrder/cli/compute_transfer_function.py
@@ -1,7 +1,93 @@
 import click
+import yaml
+import numpy as np
+from iohub import open_ome_zarr
+from recOrder.cli.settings import TransferFunctionSettings
+from recOrder.cli.parsing import config_path_option, output_dataset_options
+from waveorder.models import (
+    inplane_anisotropic_thin_pol3d,
+    isotropic_thin_3d,
+    phase_thick_3d,
+)
 
 
 @click.command()
-def compute_transfer_function():
+@config_path_option()
+@output_dataset_options()
+def compute_transfer_function(config_path, output_path):
     "Compute a transfer function from configuration"
-    return NotImplementedError
+
+    # Load config file
+    if config_path is None:
+        settings = TransferFunctionSettings()
+    else:
+        with open(config_path) as file:
+            raw_settings = yaml.safe_load(file)
+        settings = TransferFunctionSettings(**raw_settings)
+
+    click.echo("Generating transfer functions with settings:\n")
+    click.echo(yaml.dump(settings.dict()))
+    click.echo(f"Generating transfer functions and storing in {output_path}\n")
+
+    dataset = open_ome_zarr(
+        output_path, layout="fov", mode="w", channel_names=["None"]
+    )
+
+    # Pass settings to appropriate calculate_transfer_function and save
+    if settings.reconstruct_phase:
+        if settings.reconstruction_dimension == 2:
+            # Convert zyx_shape and z_pixel_size into yx_shape and z_position_list
+            settings_dict = settings.phase_transfer_function_settings.dict()
+            z_shape, y_shape, x_shape = settings_dict["zyx_shape"]
+            settings_dict["yx_shape"] = [y_shape, x_shape]
+            settings_dict["z_position_list"] = list(
+                (np.arange(z_shape) - z_shape // 2)
+                * settings_dict["z_pixel_size"]
+            )
+
+            # Remove unused parameters
+            settings_dict.pop("zyx_shape")
+            settings_dict.pop("z_pixel_size")
+            settings_dict.pop("z_padding")
+
+            # Calculate transfer functions
+            (
+                absorption_transfer_function,
+                phase_transfer_function,
+            ) = isotropic_thin_3d.calculate_transfer_function(
+                **settings_dict,
+                wavelength_illumination=settings.wavelength_illumination,
+            )
+
+            # Save
+            dataset["absorption"] = absorption_transfer_function.cpu().numpy()[
+                None, None, ...
+            ]
+            dataset["phase"] = phase_transfer_function.cpu().numpy()[
+                None, None, ...
+            ]
+
+        elif settings.reconstruction_dimension == 3:
+            (
+                real_transfer_function,
+                imaginary_transfer_function,
+            ) = phase_thick_3d.calculate_transfer_function(
+                **settings.phase_transfer_function_settings.dict(),
+                wavelength_illumination=settings.wavelength_illumination,
+            )
+            dataset["real"] = real_transfer_function.cpu().numpy()[
+                None, None, ...
+            ]
+            dataset["imaginary"] = imaginary_transfer_function.cpu().numpy()[
+                None, None, ...
+            ]
+
+    if settings.reconstruct_birefringence:
+        i2s_matrix = (
+            inplane_anisotropic_thin_pol3d.calculate_transfer_function(
+                **settings.birefringence_transfer_function_settings.dict()
+            )
+        )
+        dataset["i2s matrix"] = i2s_matrix.cpu().numpy()[None, None, None, ...]
+
+    dataset.close()

--- a/recOrder/cli/main.py
+++ b/recOrder/cli/main.py
@@ -1,0 +1,20 @@
+import click
+from recOrder.cli.view import view
+from recOrder.cli.reconstruct import reconstruct
+from recOrder.cli.compute_transfer_function import compute_transfer_function
+from recOrder.cli.apply_inverse_transfer_function import (
+    apply_inverse_transfer_function,
+)
+
+
+@click.group()
+def cli():
+    print(
+        "\033[92mrecOrder: Computational Toolkit for Label-Free Imaging\033[0m\n"
+    )
+
+
+cli.add_command(view)
+cli.add_command(reconstruct)
+cli.add_command(compute_transfer_function)
+cli.add_command(apply_inverse_transfer_function)

--- a/recOrder/cli/main.py
+++ b/recOrder/cli/main.py
@@ -9,9 +9,7 @@ from recOrder.cli.apply_inverse_transfer_function import (
 
 @click.group()
 def cli():
-    print(
-        "\033[92mrecOrder: Computational Toolkit for Label-Free Imaging\033[0m\n"
-    )
+    """\033[92mrecOrder: Computational Toolkit for Label-Free Imaging\033[0m\n"""
 
 
 cli.add_command(view)

--- a/recOrder/cli/parsing.py
+++ b/recOrder/cli/parsing.py
@@ -6,10 +6,11 @@ import glob
 from typing import Callable, Sequence
 
 
-def input_path_argument() -> Callable:
+def input_data_path_argument() -> Callable:
     def decorator(f: Callable) -> Callable:
         return click.argument(
-            "input-path",
+            "input-data-path",
+            type=click.Path(exists=True),
             nargs=1,
         )(f)
 
@@ -25,12 +26,12 @@ def config_path_option() -> Callable:
     return decorator
 
 
-def output_dataset_options() -> Callable:
+def output_dataset_options(default) -> Callable:
     click_options = [
         click.option(
             "--output-path",
             "-o",
-            default="./output.zarr",
+            default=default,
             help="Path to output.zarr",
         )
     ]

--- a/recOrder/cli/parsing.py
+++ b/recOrder/cli/parsing.py
@@ -1,0 +1,44 @@
+# lifted from dexp
+
+import click
+import warnings
+import glob
+from typing import Callable, Sequence
+
+
+def input_path_argument() -> Callable:
+    def decorator(f: Callable) -> Callable:
+        return click.argument(
+            "input-path",
+            nargs=1,
+        )(f)
+
+    return decorator
+
+
+def config_path_option() -> Callable:
+    def decorator(f: Callable) -> Callable:
+        return click.option(
+            "--config-path", "-c", default=None, help="Path to config.yml"
+        )(f)
+
+    return decorator
+
+
+def output_dataset_options() -> Callable:
+    click_options = [
+        click.option(
+            "--output-path",
+            "-o",
+            default="./output.zarr",
+            help="Path to output.zarr",
+        )
+    ]
+    # good place to add chunking, overwrite flag, etc
+
+    def decorator(f: Callable) -> Callable:
+        for opt in click_options:
+            f = opt(f)
+        return f
+
+    return decorator

--- a/recOrder/cli/printing.py
+++ b/recOrder/cli/printing.py
@@ -1,0 +1,10 @@
+import click
+import yaml
+
+
+def echo_settings(settings):
+    click.echo(yaml.dump(settings.dict()))
+
+
+def echo_headline(headline):
+    click.echo(click.style(headline, fg="green"))

--- a/recOrder/cli/reconstruct.py
+++ b/recOrder/cli/reconstruct.py
@@ -1,0 +1,7 @@
+import click
+
+
+@click.command()
+def reconstruct():
+    """Reconstruct a dataset"""
+    return NotImplementedError

--- a/recOrder/cli/reconstruct.py
+++ b/recOrder/cli/reconstruct.py
@@ -3,5 +3,5 @@ import click
 
 @click.command()
 def reconstruct():
-    """Reconstruct a dataset"""
+    """Reconstruct from config"""
     return NotImplementedError

--- a/recOrder/cli/settings.py
+++ b/recOrder/cli/settings.py
@@ -1,13 +1,14 @@
 from pydantic import BaseModel, validator
+from typing import Literal, List
 
 
 class _ReconstructionModeSettings(BaseModel):
     reconstruct_birefringence: bool = True
     reconstruct_phase: bool = True
-    reconstruction_dimension: str = "2"  # or 3
+    reconstruction_dimension: Literal["2", "3"] = "2"
 
     @validator("reconstruct_phase")
-    def either_birefringence_or_phase(cls, v, values, **kwargs):
+    def either_birefringence_or_phase(cls, v, values):
         if (not v) and (not values["reconstruct_birefringence"]):
             raise ValueError(
                 "either reconstruct_birefringence or reconstruct_phase must be True"
@@ -20,13 +21,25 @@ class _ReconstructionModeSettings(BaseModel):
 
 class _CommonTransferFunctionSettings(BaseModel):
     # common among all transfer functions
-    zyx_shape: tuple = (10, 256, 256)  # 3-tuple
+    zyx_shape: List[float] = (10, 256, 256)
     wavelength_illumination: float = 0.532
+
+    @validator("zyx_shape")
+    def zyx_shape_has_three_elements(cls, v):
+        if len(v) != 3:
+            raise ValueError(
+                f"zyx_shape must has three elements instead of {len(v)}"
+            )
 
 
 class _BirefringenceTransferFunctionSettings(BaseModel):
-    swing: float = 0.1  # TODO 0 < swing < 1
-    scheme: str = "5-State"  # TODO string literal
+    swing: float = 0.1
+    scheme: Literal["4-State", "5-State"] = "5-State"
+
+    @validator("swing")
+    def swing_range(cls, v):
+        if v <= 0 or v >= 1.0:
+            raise ValueError(f"swing = {v} should be between 0 and 1.")
 
 
 class _PhaseTransferFunctionSettings(BaseModel):
@@ -37,11 +50,32 @@ class _PhaseTransferFunctionSettings(BaseModel):
     numerical_aperture_illumination: float = 0.5
     numerical_aperture_detection: float = 1.2
 
+    @validator("z_padding")
+    def z_pad(cls, v):
+        if v < 0:
+            raise ValueError(f"z_padding = {v} cannot be negative")
+
+    @validator("numerical_aperture_illumination")
+    def na_ill(cls, v, values):
+        n = values["index_of_refraction_media"]
+        if v >= n:
+            raise ValueError(
+                f"numerical_aperture_illumination = {v} must be less than index_of_refraction_media = {n}"
+            )
+
+    @validator("numerical_aperture_detection")
+    def na_det(cls, v, values):
+        n = values["index_of_refraction_media"]
+        if v >= n:
+            raise ValueError(
+                f"numerical_aperture_detection = {v} must be less than index_of_refraction_media = {n}"
+            )
+
 
 class TransferFunctionSettings(
     _ReconstructionModeSettings,
 ):
-    common_settings: _CommonTransferFunctionSettings = (
+    common_transfer_function_settings: _CommonTransferFunctionSettings = (
         _CommonTransferFunctionSettings()
     )
     birefringence_transfer_function_settings: _BirefringenceTransferFunctionSettings = (
@@ -50,6 +84,17 @@ class TransferFunctionSettings(
     phase_transfer_function_settings: _PhaseTransferFunctionSettings = (
         _PhaseTransferFunctionSettings()
     )
+
+    # FIXME - how can I validate across settings classes? 
+    # See also: test_settings.py
+    # @validator("yx_pixel_size")
+    # def warn_unit_consistency(cls, v, values):
+    #     lamb = values["wavelength_illumination"]
+    #     ratio = v / lamb
+    #     if ratio < 1.0 / 20 or ratio > 20:
+    #         raise Warning(
+    #             f"yx_pixel_size ({v}) / wavelength_illumination ({lamb}) = {ratio}. Did you use consistent units?"
+    #         )
 
 
 ########## apply inverse transfer function settings ##########

--- a/recOrder/cli/settings.py
+++ b/recOrder/cli/settings.py
@@ -1,0 +1,81 @@
+from pydantic import BaseModel, validator
+
+
+class _ReconstructionModeSettings(BaseModel):
+    reconstruct_birefringence: bool = True
+    reconstruct_phase: bool = True
+    reconstruction_dimension: str = "2"  # or 3
+
+    @validator("reconstruct_phase")
+    def either_birefringence_or_phase(cls, v, values, **kwargs):
+        if (not v) and (not values["reconstruct_birefringence"]):
+            raise ValueError(
+                "either reconstruct_birefringence or reconstruct_phase must be True"
+            )
+        return v
+
+
+########## transfer function settings ##########
+
+
+class _CommonTransferFunctionSettings(BaseModel):
+    # common among all transfer functions
+    zyx_shape: tuple = (10, 256, 256)  # 3-tuple
+    wavelength_illumination: float = 0.532
+
+
+class _BirefringenceTransferFunctionSettings(BaseModel):
+    swing: float = 0.1  # TODO 0 < swing < 1
+    scheme: str = "5-State"  # TODO string literal
+
+
+class _PhaseTransferFunctionSettings(BaseModel):
+    yx_pixel_size: float = 6.5 / 20
+    z_pixel_size: float = 2.0
+    z_padding: int = 0
+    index_of_refraction_media: float = 1.3
+    numerical_aperture_illumination: float = 0.5
+    numerical_aperture_detection: float = 1.2
+
+
+class TransferFunctionSettings(
+    _ReconstructionModeSettings,
+):
+    common_settings: _CommonTransferFunctionSettings = (
+        _CommonTransferFunctionSettings()
+    )
+    birefringence_transfer_function_settings: _BirefringenceTransferFunctionSettings = (
+        _BirefringenceTransferFunctionSettings()
+    )
+    phase_transfer_function_settings: _PhaseTransferFunctionSettings = (
+        _PhaseTransferFunctionSettings()
+    )
+
+
+########## apply inverse transfer function settings ##########
+
+
+class _BirefringenceApplyInverseSettings(BaseModel):
+    orientation_flip: bool = False
+    orientation_rotate: bool = False
+
+
+class _PhaseApplyInverseSettings(BaseModel):
+    reconstruction_algorithm: str = "Tikhonov"
+    reconstruction_parameters: list = [0.0, 0.0]
+
+
+class ApplyInverseSettings(_ReconstructionModeSettings):
+    birefringence_apply_inverse_settings: _BirefringenceApplyInverseSettings = (
+        _BirefringenceApplyInverseSettings()
+    )
+    phase_apply_inverse_settings: _PhaseApplyInverseSettings = (
+        _PhaseApplyInverseSettings()
+    )
+
+
+########## reconstruction settings ##########
+
+
+class ReconstructionSettings(TransferFunctionSettings, ApplyInverseSettings):
+    pass

--- a/recOrder/cli/settings.py
+++ b/recOrder/cli/settings.py
@@ -3,8 +3,8 @@ from typing import Literal, List
 
 
 class _UniversalSettings(BaseModel):
-    # these parameters are needed for every step:
-    #  - compute-transfer-function,
+    # these parameters for needed for each step:
+    #  - compute-transfer-function
     #  - apply-inverse-transfer-function
     #  - reconstruct
     reconstruct_birefringence: bool = True
@@ -34,7 +34,7 @@ class _UniversalSettings(BaseModel):
 
 class _BirefringenceTransferFunctionSettings(BaseModel):
     swing: float = 0.1
-    scheme: Literal["4-State", "5-State"] = "5-State"
+    scheme: Literal["4-State", "5-State"] = "4-State"
 
     @validator("swing")
     def swing_range(cls, v):
@@ -44,7 +44,7 @@ class _BirefringenceTransferFunctionSettings(BaseModel):
 
 
 class _PhaseTransferFunctionSettings(BaseModel):
-    zyx_shape: List[int] = [10, 256, 256]
+    zyx_shape: List[int] = [16, 128, 256]
     yx_pixel_size: float = 6.5 / 20
     z_pixel_size: float = 2.0
     z_padding: int = 0
@@ -85,9 +85,8 @@ class _PhaseTransferFunctionSettings(BaseModel):
         return v
 
 
-class TransferFunctionSettings(
-    _UniversalSettings,
-):
+class TransferFunctionSettings(BaseModel):
+    universal_settings: _UniversalSettings = _UniversalSettings()
     birefringence_transfer_function_settings: _BirefringenceTransferFunctionSettings = (
         _BirefringenceTransferFunctionSettings()
     )
@@ -111,18 +110,20 @@ class TransferFunctionSettings(
 
 
 class _BirefringenceApplyInverseSettings(BaseModel):
-    background_path: DirectoryPath = None
+    background_path: str = (
+        None  # I'd DirectoryPath but it's not JSON serializable?
+    )
     remove_estimated_background: bool = False
     orientation_flip: bool = False
     orientation_rotate: bool = False
 
 
 class _PhaseApplyInverseSettings(BaseModel):
-    reconstruction_algorithm: str = "Tikhonov"
+    reconstruction_algorithm: Literal["Tikhonov", "TV"] = "Tikhonov"
     reconstruction_parameters: list = [0.0, 0.0]
 
 
-class ApplyInverseSettings(_UniversalSettings):
+class ApplyInverseSettings(BaseModel):
     birefringence_apply_inverse_settings: _BirefringenceApplyInverseSettings = (
         _BirefringenceApplyInverseSettings()
     )

--- a/recOrder/cli/settings.py
+++ b/recOrder/cli/settings.py
@@ -69,18 +69,18 @@ class _PhaseTransferFunctionSettings(BaseModel):
     @validator("numerical_aperture_illumination")
     def na_ill(cls, v, values):
         n = values["index_of_refraction_media"]
-        if v >= n:
+        if v > n:
             raise ValueError(
-                f"numerical_aperture_illumination = {v} must be less than index_of_refraction_media = {n}"
+                f"numerical_aperture_illumination = {v} must be less than or equal to index_of_refraction_media = {n}"
             )
         return v
 
     @validator("numerical_aperture_detection")
     def na_det(cls, v, values):
         n = values["index_of_refraction_media"]
-        if v >= n:
+        if v > n:
             raise ValueError(
-                f"numerical_aperture_detection = {v} must be less than index_of_refraction_media = {n}"
+                f"numerical_aperture_detection = {v} must be less than or equal to index_of_refraction_media = {n}"
             )
         return v
 

--- a/recOrder/cli/view.py
+++ b/recOrder/cli/view.py
@@ -1,7 +1,7 @@
 import click
 import napari
 
-v = napari.Viewer()  # open viewer right away to use on hpc
+#v = napari.Viewer()  # open viewer right away to use on hpc
 import numpy as np
 from recOrder.io.utils import ret_ori_overlay
 from iohub.reader import print_info, _infer_format
@@ -170,14 +170,7 @@ def _create_napari_viewer(arrays, layers, layer_names, slice_names, overlay):
     napari.run()
 
 
-@click.group()
-def cli():
-    print(
-        "\033[92mrecOrder: Computational Toolkit for Label-Free Imaging\033[0m\n"
-    )
-
-
-@cli.command()
+@click.command()
 @click.help_option("-h", "--help")
 @click.argument("filename")
 @click.option(

--- a/recOrder/io/utils.py
+++ b/recOrder/io/utils.py
@@ -2,6 +2,7 @@ import glob
 import logging
 import os
 import psutil
+import torch
 import textwrap
 import tifffile as tiff
 import numpy as np
@@ -53,6 +54,7 @@ def extract_reconstruction_parameters(reconstructor, magnification=None):
     return attr_dict
 
 
+# TO BE DEPRECATED
 def load_bg(bg_path, height, width, ROI=None):
     """
     Parameters
@@ -99,6 +101,16 @@ def load_bg(bg_path, height, width, ROI=None):
     return bg_img_arr  # CYX
 
 
+# NEW VERSION TO BE DOCUMENTED AND/OR MOVED TO IOHUB
+def new_load_background(background_path):
+    tiff_path_list = glob.glob(os.path.join(background_path, "*.tif"))
+    tiff_path_list.sort()
+    background_image_list = []
+    for tiff_path in tiff_path_list:
+        background_image_list.append(tiff.imread(tiff_path))
+    return torch.tensor(background_image_list, dtype=torch.float32)  # CYX
+
+
 def create_grid_from_coordinates(xy_coords, rows, columns):
     """
     Function to create a grid from XY-position coordinates.  Useful for generating HCS Zarr metadata.
@@ -133,7 +145,6 @@ def create_grid_from_coordinates(xy_coords, rows, columns):
 
     for row in range(rows):
         for col in range(columns):
-
             # append position index (key) into a final grid by indexed into the coordinate map (values)
             pos_index_grid[row, col] = keys[vals.index(list(grid[row, col]))]
 

--- a/recOrder/io/utils.py
+++ b/recOrder/io/utils.py
@@ -11,6 +11,7 @@ from matplotlib.colors import hsv_to_rgb
 from waveorder.waveorder_reconstructor import waveorder_microscopy
 
 
+# TO BE DEPRECATED
 def extract_reconstruction_parameters(reconstructor, magnification=None):
     """
     Function that extracts the reconstruction parameters from a waveorder reconstructor.  Works for waveorder_microscopy class.

--- a/recOrder/tests/cli_tests/test_cli.py
+++ b/recOrder/tests/cli_tests/test_cli.py
@@ -7,4 +7,4 @@ def test_main():
     result = runner.invoke(cli)
 
     assert result.exit_code == 0
-    assert "Usage" in result.output
+    assert "Toolkit" in result.output

--- a/recOrder/tests/cli_tests/test_cli.py
+++ b/recOrder/tests/cli_tests/test_cli.py
@@ -8,3 +8,6 @@ def test_main():
 
     assert result.exit_code == 0
     assert "Toolkit" in result.output
+
+def test_compute_transfer_function():
+    

--- a/recOrder/tests/cli_tests/test_cli.py
+++ b/recOrder/tests/cli_tests/test_cli.py
@@ -1,0 +1,10 @@
+from recOrder.cli.main import cli
+from click.testing import CliRunner
+
+
+def test_main():
+    runner = CliRunner()
+    result = runner.invoke(cli)
+
+    assert result.exit_code == 0
+    assert "Usage" in result.output

--- a/recOrder/tests/cli_tests/test_settings.py
+++ b/recOrder/tests/cli_tests/test_settings.py
@@ -4,14 +4,10 @@ from pydantic import ValidationError
 
 
 def test_reconstruction_mode_settings():
-    test_settings = settings._ReconstructionModeSettings(
-        reconstruction_dimension="2"
-    )
+    test_settings = settings._UniversalSettings(reconstruction_dimension=2)
 
     with pytest.raises(ValidationError):
-        test_settings = settings._ReconstructionModeSettings(
-            reconstruction_dimension="1"
-        )
+        test_settings = settings._UniversalSettings(reconstruction_dimension=1)
 
 
 def test_common_tf_settings():

--- a/recOrder/tests/cli_tests/test_settings.py
+++ b/recOrder/tests/cli_tests/test_settings.py
@@ -1,0 +1,29 @@
+import pytest
+from recOrder.cli import settings
+from pydantic import ValidationError
+
+
+def test_transfer_function_settings():
+    tf_settings = settings.TransferFunctionSettings()
+    assert tf_settings.phase_settings.yx_pixel_size == 6.5 / 20
+
+    with pytest.raises(ValidationError):
+        settings.TransferFunctionSettings(reconstruct_birefringence=10)
+
+    test_settings = {
+        "reconstruct_birefringence": False,
+        "reconstruct_phase": False,
+    }
+
+    with pytest.raises(ValidationError):
+        tf_settings = settings.TransferFunctionSettings(**test_settings)
+
+
+def test_inverse_settings():
+    inverse_settings = settings.ApplyInverseSettings()
+    assert inverse_settings.reconstruct_phase == True
+
+
+def test_recon_settings():
+    recon_settings = settings.ReconstructionSettings()
+    assert recon_settings.reconstruct_phase == True

--- a/recOrder/tests/cli_tests/test_settings.py
+++ b/recOrder/tests/cli_tests/test_settings.py
@@ -3,9 +3,59 @@ from recOrder.cli import settings
 from pydantic import ValidationError
 
 
+def test_reconstruction_mode_settings():
+    test_settings = settings._ReconstructionModeSettings(
+        reconstruction_dimension="2"
+    )
+
+    with pytest.raises(ValidationError):
+        test_settings = settings._ReconstructionModeSettings(
+            reconstruction_dimension="1"
+        )
+
+
+def test_common_tf_settings():
+    test_settings = settings._CommonTransferFunctionSettings(
+        zyx_shape=(2, 3, 4)
+    )
+
+    with pytest.raises(ValidationError):
+        test_settings = settings._CommonTransferFunctionSettings(zyx_shape=2)
+
+    with pytest.raises(ValidationError):
+        test_settings = settings._CommonTransferFunctionSettings(
+            zyx_shape=(2, 3)
+        )
+
+
+def test_biref_tf_settings():
+    test_settings = settings._BirefringenceTransferFunctionSettings(
+        scheme="4-State", swing=0.1
+    )
+
+    with pytest.raises(ValidationError):
+        test_settings = settings._BirefringenceTransferFunctionSettings(
+            swing=1.1
+        )
+
+    with pytest.raises(ValidationError):
+        test_settings = settings._BirefringenceTransferFunctionSettings(
+            scheme="Test"
+        )
+
+
+def test_phase_tf_settings():
+    with pytest.raises(ValidationError):
+        test_settings = settings._PhaseTransferFunctionSettings(
+            index_of_refraction_media=1.0, numerical_aperture_detection=1.1
+        )
+
+
 def test_transfer_function_settings():
     tf_settings = settings.TransferFunctionSettings()
-    assert tf_settings.phase_settings.yx_pixel_size == 6.5 / 20
+    assert (
+        tf_settings.phase_transfer_function_settings.yx_pixel_size == 6.5 / 20
+    )
 
     with pytest.raises(ValidationError):
         settings.TransferFunctionSettings(reconstruct_birefringence=10)
@@ -17,6 +67,18 @@ def test_transfer_function_settings():
 
     with pytest.raises(ValidationError):
         tf_settings = settings.TransferFunctionSettings(**test_settings)
+
+    # FIXME
+    # See also: settings.py
+    # with pytest.raises(Warning):
+    #     ss = settings.TransferFunctionSettings(
+    #         common_transfer_function_settings=settings._CommonTransferFunctionSettings(
+    #             wavelength_illumination=532
+    #         ),
+    #         phase_transfer_function_settings=settings._PhaseTransferFunctionSettings(
+    #             yx_pixel_size=0.25
+    #         ),
+    #     )
 
 
 def test_inverse_settings():

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,8 +65,8 @@ dev =
 
 [options.entry_points]
 console_scripts =
-	recorder = recOrder.scripts.cli:cli
-	recOrder = recOrder.scripts.cli:cli
+	recorder = recOrder.cli.main:cli
+	recOrder = recOrder.cli.main:cli
 	
 napari.manifest =
 	recOrder = recOrder:napari.yaml


### PR DESCRIPTION
@ziw-liu @mattersoflight I can demo my progress tomorrow to help us put together a plan. 

I've tested this branch against `waveorder`'s `pol-refactor` branch. 

Confirmed working:
- torch installation on hummingbird 
- new CLI `calculate-transfer-function` and `apply-inverse-transfer-function` can perform all reconstruction steps
- GUI buttons are connected to the new CLI: all 3 acquisition buttons (in both 2D and 3D modes) return results to the screen. Out-of-the-box polarization acquisitions look good. The GUI calls the CLI functions and spits out commands to recreate the transfer functions and reconstructions...initial tests look good.

Major limitations to address:
- [ ] phase reconstructions need some tuning...I expect I've introduced a bug on the `recOrder` side based on my tests, but I'll look closer tomorrow
- [ ] background corrections are not connected...I had some issues handling strings vs. paths in the yaml file. @ziw-liu I may grab your help here.
- [ ] regularization parameters are not connected and currently use defaults...I had an issue handling a variable number of parameters and passing to kwargs. @ziw-liu if you have capacity I'll grab you here as well. 
- [ ] I have implemented a very simple file organization scheme (all files go into the snap_directory, and I'm currently recalculating the transfer functions for every acquisition. A better location for these files will enable easy reuse. 

Minor limitations:
- [ ] haven't implemented an end-to-end `reconstruct` method yet...this will be a fairly easy last step
- [ ] haven't removed much of the unused code in `recOrder`...commented for now to smooth the transition
- [ ] gpu-related buttons are no longer connected
- [ ] although I'm saving the transfer functions to file, I don't have easy visualizations working because of minor issues related to real vs. complex values. 
- docs, CLI automated testing, much more! 
- `apply_inverse_transfer_function` is where most of the densest `recOrder`-`waveorder` logic lives (these recOrder settings require these TFs applied in this way to these `waveorder` models). I could likely use some improvement to my use of `iohub`.