### PR TITLE
Depend on MM 2023-04-18

### DIFF
--- a/docs/microscope-installation-guide.md
+++ b/docs/microscope-installation-guide.md
@@ -42,7 +42,7 @@ Install `Micromanager 2.0` nightly build `20230418` (https://micro-manager.org/M
 
 **Note:** We have tested recOrder with `20230418`, but most features will work with newer builds. We recommend testing a minimal installation with `20230418` before testing with a different nightly build or additional device drivers. 
 
-Before launching `Micromanager`, download the Meadowlark device adapters and calibration files from the [release page](https://github.com/mehta-lab/recOrder/releases/) and place these three unzipped files into your `Micromanager` folder (likely `C:\Program Files\Micro-Manager` or similar). 
+Before launching `Micromanager`, download the calibration files and USB device adapter from the [release page](https://github.com/mehta-lab/recOrder/releases/) and place this pair of unzipped files into your `Micromanager` folder (likely `C:\Program Files\Micro-Manager` or similar). 
 
 Launch `Micromanager`, open `Devices > Hardware Configuration Wizard...`, and add the `MeadowlarkLcOpenSource` device to your configuration. Confirm your installation by opening `Devices > Device Property Browser...` and confirming that `MeadowlarkLCOpenSource` properties appear. 
 

--- a/docs/microscope-installation-guide.md
+++ b/docs/microscope-installation-guide.md
@@ -27,9 +27,9 @@ should launch napari (may take 15 seconds on a fresh installation) with the recO
  
 ## Install and configure `Micromanager`
 
-Install `Micromanager 2.0` nightly build `20220920` (https://micro-manager.org/Micro-Manager_Nightly_Builds). 
+Install `Micromanager 2.0` nightly build `20230418` (https://micro-manager.org/Micro-Manager_Nightly_Builds). 
 
-**Note:** We have tested recOrder with `20220920`, but most features will work with newer builds. We recommend testing a minimal installation with `20220920` before testing with a different nightly build or additional device drivers. 
+**Note:** We have tested recOrder with `20230418`, but most features will work with newer builds. We recommend testing a minimal installation with `20230418` before testing with a different nightly build or additional device drivers. 
 
 Before launching `Micromanager`, download the Meadowlark device adapters and calibration files from the [release page](https://github.com/mehta-lab/recOrder/releases/) and place these three unzipped files into your `Micromanager` folder (likely `C:\Program Files\Micro-Manager` or similar). 
 

--- a/docs/microscope-installation-guide.md
+++ b/docs/microscope-installation-guide.md
@@ -7,6 +7,17 @@ This guide will walk through a complete recOrder installation consisting of:
 
 Before you start you will need a machine with Windows 10, a Meadowlark DS5020 connected to a liquid crystal device, and a microscope system compatible with `Micromanager`. 
 
+## Install Meadowlark DS5020 and liquid crystals
+
+**New installations:** start by installing the Meadowlark DS5020 and liquid crystals using the software on the USB stick provided by Meadowlark. You will need to install USB drivers and CellDrive5000 for compatibility with `recOrder-napari==0.4.0`.
+
+**All installations, including upgrades:** open CellDrive5000 and double click the Meadowlark Optics logo. **If "PC software version" != 1.08, you will need to upgrade your USB drivers and CellDrive5000.** We have successfully upgraded existing installations by following these steps:
+
+- From "Add and remove programs", remove CellDrive5000 and "National Instruments Software".
+- From "Device manager", open the "Meadowlark Optics" group, right click `mlousb`, click "Uninstall device", check "Delete the driver software for this device", and click "Uninstall". Uninstall `Meadowlark Optics D5020 LC Driver` following the same steps.
+- Using the USB stick provided by Meadowlark, reinstall the USB drivers and CellDrive5000. 
+- Confirm that "PC software version" == 1.08
+
 ## Install recOrder software
 
 (Optional but recommended) install [anaconda](https://www.anaconda.com/products/distribution) and create a virtual environment  

--- a/docs/microscope-installation-guide.md
+++ b/docs/microscope-installation-guide.md
@@ -17,6 +17,7 @@ Before you start you will need a machine with Windows 10, a Meadowlark DS5020 co
 - From "Device manager", open the "Meadowlark Optics" group, right click `mlousb`, click "Uninstall device", check "Delete the driver software for this device", and click "Uninstall". Uninstall `Meadowlark Optics D5020 LC Driver` following the same steps.
 - Using the USB stick provided by Meadowlark, reinstall the USB drivers and CellDrive5000. 
 - Confirm that "PC software version" == 1.08
+- **Upgrading users:** you will need to reinstall the Meadowlark device to your micromanager configuration file, because the device driver's name has changed to `MeadowlarkLC`. 
 
 ## Install recOrder software
 

--- a/docs/microscope-installation-guide.md
+++ b/docs/microscope-installation-guide.md
@@ -43,11 +43,11 @@ should launch napari (may take 15 seconds on a fresh installation) with the recO
  
 ## Install and configure `Micromanager`
 
-Install `Micromanager 2.0` nightly build `20230418` (https://micro-manager.org/Micro-Manager_Nightly_Builds). 
+Download and install [`Micromanager 2.0` nightly build `20230418` (~150 MB link).](https://download.micro-manager.org/nightly/2.0/Windows/MMSetup_64bit_2.0.1_20230418.exe)
 
 **Note:** We have tested recOrder with `20230418`, but most features will work with newer builds. We recommend testing a minimal installation with `20230418` before testing with a different nightly build or additional device drivers. 
 
-Before launching `Micromanager`, download the calibration file `.csv` and USB driver `.dll` from the [release page](https://github.com/mehta-lab/recOrder/releases/) and place this pair of unzipped files into your `Micromanager` folder (likely `C:\Program Files\Micro-Manager` or similar). 
+Before launching `Micromanager`, download the calibration file `.csv` and USB driver dll from the [release page](https://github.com/mehta-lab/recOrder/releases/) and place this pair of unzipped files into your `Micromanager` folder (likely `C:\Program Files\Micro-Manager` or similar). 
 
 Launch `Micromanager`, open `Devices > Hardware Configuration Wizard...`, and add the `MeadowlarkLcOpenSource` device to your configuration. Confirm your installation by opening `Devices > Device Property Browser...` and confirming that `MeadowlarkLCOpenSource` properties appear. 
 

--- a/docs/microscope-installation-guide.md
+++ b/docs/microscope-installation-guide.md
@@ -47,7 +47,7 @@ Install `Micromanager 2.0` nightly build `20230418` (https://micro-manager.org/M
 
 **Note:** We have tested recOrder with `20230418`, but most features will work with newer builds. We recommend testing a minimal installation with `20230418` before testing with a different nightly build or additional device drivers. 
 
-Before launching `Micromanager`, download the calibration files and USB device adapter from the [release page](https://github.com/mehta-lab/recOrder/releases/) and place this pair of unzipped files into your `Micromanager` folder (likely `C:\Program Files\Micro-Manager` or similar). 
+Before launching `Micromanager`, download the calibration file `.csv` and USB driver `.dll` from the [release page](https://github.com/mehta-lab/recOrder/releases/) and place this pair of unzipped files into your `Micromanager` folder (likely `C:\Program Files\Micro-Manager` or similar). 
 
 Launch `Micromanager`, open `Devices > Hardware Configuration Wizard...`, and add the `MeadowlarkLcOpenSource` device to your configuration. Confirm your installation by opening `Devices > Device Property Browser...` and confirming that `MeadowlarkLCOpenSource` properties appear. 
 

--- a/docs/microscope-installation-guide.md
+++ b/docs/microscope-installation-guide.md
@@ -9,15 +9,19 @@ Before you start you will need a machine with Windows 10, a Meadowlark DS5020 co
 
 ## Install Meadowlark DS5020 and liquid crystals
 
-**New installations:** start by installing the Meadowlark DS5020 and liquid crystals using the software on the USB stick provided by Meadowlark. You will need to install USB drivers and CellDrive5000 for compatibility with `recOrder-napari==0.4.0`.
+Start by installing the Meadowlark DS5020 and liquid crystals using the software on the USB stick provided by Meadowlark. You will need to install the USB drivers and CellDrive5000.
 
-**All installations, including upgrades:** open CellDrive5000 and double click the Meadowlark Optics logo. **If "PC software version" != 1.08, you will need to upgrade your USB drivers and CellDrive5000.** We have successfully upgraded existing installations by following these steps:
+**Check your installation versions** by opening CellDrive5000 and double clicking the Meadowlark Optics logo. **We have tested `recOrder == 0.4.0` with "PC software version 1.08" and "Controller firmware version 1.04",** and you will need to upgrade if your software and firmware versions are older. 
+
+To upgrade your "PC software version" use these steps:
 
 - From "Add and remove programs", remove CellDrive5000 and "National Instruments Software".
 - From "Device manager", open the "Meadowlark Optics" group, right click `mlousb`, click "Uninstall device", check "Delete the driver software for this device", and click "Uninstall". Uninstall `Meadowlark Optics D5020 LC Driver` following the same steps.
 - Using the USB stick provided by Meadowlark, reinstall the USB drivers and CellDrive5000. 
 - Confirm that "PC software version" == 1.08
 - **Upgrading users:** you will need to reinstall the Meadowlark device to your micromanager configuration file, because the device driver's name has changed to `MeadowlarkLC`. 
+
+To upgrade your DS5020's firmware, use Meadowlark's "Firmware Updater".
 
 ## Install recOrder software
 

--- a/recOrder/calib/Calibration.py
+++ b/recOrder/calib/Calibration.py
@@ -18,7 +18,7 @@ from recOrder.io.utils import MockEmitter
 from datetime import datetime
 from importlib_metadata import version
 
-LC_DEVICE_NAME = "MeadowlarkLcOpenSource"
+LC_DEVICE_NAME = "MeadowlarkLC"
 
 
 class QLIPP_Calibration:

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -879,7 +879,7 @@ class MainWidget(QWidget):
         -------
 
         """
-        RECOMMENDED_MM = "20220920"
+        RECOMMENDED_MM = "20230418"
         ZMQ_TARGET_VERSION = "4.2.0"
         try:
             self.mmc = Core(convert_camel_case=False)


### PR DESCRIPTION
This PR upgrades `recOrder` to depend on MM nightly build `2023-04-18`. 

I have tested this branch on automaton in all three calibration modes. 

Upgrading an existing `recOrder-napari==0.3.0` is fairly involved---budget at least 60 minutes. The simplest steps we've found are:
- uninstall CellDrive5000, the associated USB drivers, and "National Instruments Software"
- use the Meadowlark-distributed USB drive to reinstall CellDrive5000 and USB drivers with the upgraded versions. (@ieivanov should we distribute this software to upgrading users by hand? - I think our only upgrading users are us and the Elicieri lab?)
- upgrade your configuration file (the device name has changed)

This fixes most of #311, but I am not closing it because we are still distributing one device driver and the `.csv` file via `recOrder` releases.

Thanks to @edyoshikun and @ieivanov for the help with developing these upgrade instructions. 