### PR TITLE
Draw birefringence overlay on napari layers event

### DIFF
--- a/recOrder/io/utils.py
+++ b/recOrder/io/utils.py
@@ -1,3 +1,4 @@
+from typing import Literal
 import glob
 import logging
 import os
@@ -254,7 +255,9 @@ def generic_hsv_overlay(
     return overlay_final[0] if mode == "2D" else overlay_final
 
 
-def ret_ori_overlay(retardance, orientation, ret_max=10, cmap="JCh"):
+def ret_ori_overlay(
+    retardance, orientation, ret_max=10, cmap: Literal["JCh", "HSV"] = "JCh"
+):
     """
     This function will create an overlay of retardance and orientation with two different colormap options.
     HSV is the standard Hue, Saturation, Value colormap while JCh is a similar colormap but is perceptually uniform.
@@ -273,7 +276,8 @@ def ret_ori_overlay(retardance, orientation, ret_max=10, cmap="JCh"):
     """
     if retardance.shape != orientation.shape:
         raise ValueError(
-            f"Retardance and Orientation shapes do not match: {retardance.shape} vs. {orientation.shape}"
+            "Retardance and Orientation shapes do not match: "
+            f"{retardance.shape} vs. {orientation.shape}"
         )
 
     # Prepare input and output arrays

--- a/recOrder/io/utils.py
+++ b/recOrder/io/utils.py
@@ -282,9 +282,8 @@ def ret_ori_overlay(
 
     # Prepare input and output arrays
     ret_ = np.clip(retardance, 0, ret_max)  # clip and copy
-    ori_ = (
-        np.copy(orientation) * 360 / np.pi
-    )  # convert 180 degree range into 360 to match periodicity of hue.
+    # Convert 180 degree range into 360 to match periodicity of hue.
+    ori_ = orientation * 360 / np.pi
     overlay_final = np.zeros_like(retardance)
 
     # FIX ME: this binning code leads to artifacts.

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -1168,6 +1168,10 @@ class MainWidget(QWidget):
             )
             self._draw_bire_overlay()
         if event.source[-1].name == channels[1]:
+            logging.info(
+                "Detected orientation layer in updated layer list."
+                "Setting its colormap to HSV"
+            )
             self.viewer.layers[channels[1]].colormap = "hsv"
 
     def _draw_bire_overlay(self):

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -1157,13 +1157,14 @@ class MainWidget(QWidget):
         )
 
     def handle_layers_updated(self, event):
+        channels = ["Retardance", "Orientation"]
         if (
-            "Retardance" in self.viewer.layers
-            and "Orientation" in self.viewer.layers
-            and ("Retardance" in event.source or "Orientation" in event.source)
+            channels[0] in event.source
+            and channels[1] in event.source
+            and event.source[-1].name in channels
         ):
-            logging.debug(
-                "Detected birefringence layers in changed layer list."
+            logging.info(
+                "Detected birefringence layers in updated layer list."
             )
             self._draw_bire_overlay()
 

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -1167,6 +1167,8 @@ class MainWidget(QWidget):
                 "Detected birefringence layers in updated layer list."
             )
             self._draw_bire_overlay()
+        if event.source[-1].name == channels[1]:
+            self.viewer.layers[channels[1]].colormap = "hsv"
 
     def _draw_bire_overlay(self):
         def _layer_data(name: str):

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -1186,7 +1186,7 @@ class MainWidget(QWidget):
         )
         worker.start()
         logging.debug(f"Updating the birefringence overlay layer.")
-        if retardance.size >= 16 * 2048 * 2048:
+        if retardance.size >= 2 * 2048 * 2048:
             show_info("Generating large overlay. This might take a moment...")
         worker.returned.connect(_draw)
 

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -1186,6 +1186,8 @@ class MainWidget(QWidget):
         )
         worker.start()
         logging.debug(f"Updating the birefringence overlay layer.")
+        if retardance.size >= 16 * 2048 * 2048:
+            show_info("Generating large overlay. This might take a moment...")
         worker.returned.connect(_draw)
 
     @Slot(object)
@@ -1195,8 +1197,6 @@ class MainWidget(QWidget):
             name = channel + self.acq_mode
             cmap = "gray" if channel != "Orientation" else "hsv"
             self._add_or_update_image_layer(value[i], name, cmap=cmap)
-        if self.acq_mode == "3D":
-            show_info("Generating 3D overlay. This might take a moment...")
 
     @Slot(object)
     def handle_phase_image_update(self, value):

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -1160,6 +1160,7 @@ class MainWidget(QWidget):
         if (
             "Retardance" in self.viewer.layers
             and "Orientation" in self.viewer.layers
+            and ("Retardance" in event.source or "Orientation" in event.source)
         ):
             logging.debug(
                 "Detected birefringence layers in changed layer list."

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -1186,7 +1186,7 @@ class MainWidget(QWidget):
         )
         worker.start()
         logging.debug(f"Updating the birefringence overlay layer.")
-        worker.returne.connect(_draw)
+        worker.returned.connect(_draw)
 
     @Slot(object)
     def handle_bire_image_update(self, value: NDArray):

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -1196,7 +1196,7 @@ class MainWidget(QWidget):
     def handle_bire_image_update(self, value: NDArray):
         # generate overlay in a separate thread
         for i, channel in enumerate(("Retardance", "Orientation")):
-            name = channel + self.acq_mode
+            name = channel
             cmap = "gray" if channel != "Orientation" else "hsv"
             self._add_or_update_image_layer(value[i], name, cmap=cmap)
 

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -1193,7 +1193,7 @@ class MainWidget(QWidget):
             cmap=self.colormap,
         )
         worker.start()
-        logging.debug(f"Updating the birefringence overlay layer.")
+        logging.info(f"Updating the birefringence overlay layer.")
         if retardance.size >= 2 * 2048 * 2048:
             show_info("Generating large overlay. This might take a moment...")
         worker.returned.connect(_draw)

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -1,46 +1,49 @@
 # TODO: remove in Python 3.11
 from __future__ import annotations
 
-from recOrder.calib.Calibration import QLIPP_Calibration, LC_DEVICE_NAME
-from pycromanager import Core, Studio, zmq_bridge
-from qtpy.QtCore import Slot, Signal, Qt
-from qtpy.QtWidgets import QWidget, QFileDialog, QSizePolicy, QSlider
-from qtpy.QtGui import QPixmap, QColor
-from superqt import QDoubleRangeSlider, QRangeSlider
-from recOrder.calib import Calibration
-from recOrder.calib.calibration_workers import (
-    CalibrationWorker,
-    BackgroundCaptureWorker,
-    load_calibration,
-)
-from recOrder.acq.acquisition_workers import (
-    PolarizationAcquisitionWorker,
-    BFAcquisitionWorker,
-)
-from recOrder.plugin import gui
-from recOrder.io.core_functions import set_lc_state, snap_and_average
-from recOrder.io.metadata_reader import MetadataReader
-from recOrder.io.utils import ret_ori_overlay
-from waveorder.waveorder_reconstructor import waveorder_microscopy
-from pathlib import Path, PurePath
-from napari import Viewer
-from napari.utils.notifications import show_warning, show_info
-from napari.qt.threading import create_worker
-from numpydoc.docscrape import NumpyDocString
-from packaging import version
-import numpy as np
-from numpy.typing import NDArray
-import dask.array as da
-from dask import delayed
-import os
-from os.path import dirname
 import json
 import logging
+import os
 import textwrap
-import yaml
+import time
+from os.path import dirname
+from pathlib import Path, PurePath
 
 # type hint/check
 from typing import TYPE_CHECKING
+
+import dask.array as da
+import numpy as np
+import yaml
+from dask import delayed
+from napari import Viewer
+from napari.qt.threading import create_worker
+from napari.utils.notifications import show_info, show_warning
+from numpy.typing import NDArray
+from numpydoc.docscrape import NumpyDocString
+from packaging import version
+from pycromanager import Core, Studio, zmq_bridge
+from qtpy.QtCore import Qt, Signal, Slot
+from qtpy.QtGui import QColor, QPixmap
+from qtpy.QtWidgets import QFileDialog, QSizePolicy, QSlider, QWidget
+from superqt import QDoubleRangeSlider, QRangeSlider
+from waveorder.waveorder_reconstructor import waveorder_microscopy
+
+from recOrder.acq.acquisition_workers import (
+    BFAcquisitionWorker,
+    PolarizationAcquisitionWorker,
+)
+from recOrder.calib import Calibration
+from recOrder.calib.Calibration import LC_DEVICE_NAME, QLIPP_Calibration
+from recOrder.calib.calibration_workers import (
+    BackgroundCaptureWorker,
+    CalibrationWorker,
+    load_calibration,
+)
+from recOrder.io.core_functions import set_lc_state, snap_and_average
+from recOrder.io.metadata_reader import MetadataReader
+from recOrder.io.utils import ret_ori_overlay
+from recOrder.plugin import gui
 
 # avoid runtime import error
 if TYPE_CHECKING:
@@ -1137,6 +1140,8 @@ class MainWidget(QWidget):
         if name in self.viewer.layers:
             self.viewer.layers[name].data = image
             if move_to_top:
+                logging.debug(f"Moving layer {name} to the top.")
+                time.sleep(0.5)
                 src_index = self.viewer.layers.index(name)
                 self.viewer.layers.move(src_index, dest_index=-1)
         else:

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -225,7 +225,8 @@ class MainWidget(QWidget):
         )
 
         # hook to render overlay
-        self.viewer.layers.events.changed.connect(self.handle_layers_updated)
+        # acquistion updates existing layers and moves them to the top which triggers this event
+        self.viewer.layers.events.moved.connect(self.handle_layers_updated)
         self.viewer.layers.events.inserted.connect(self.handle_layers_updated)
 
         # Commenting for 0.3.0. Consider debugging or deleting for 1.0.0.
@@ -1141,7 +1142,6 @@ class MainWidget(QWidget):
             self.viewer.layers[name].data = image
             if move_to_top:
                 logging.debug(f"Moving layer {name} to the top.")
-                time.sleep(0.5)
                 src_index = self.viewer.layers.index(name)
                 self.viewer.layers.move(src_index, dest_index=-1)
         else:

--- a/recOrder/tests/util_tests/test_overlays.py
+++ b/recOrder/tests/util_tests/test_overlays.py
@@ -1,0 +1,65 @@
+import hypothesis.extra.numpy as npst
+import hypothesis.strategies as st
+import numpy as np
+from hypothesis import given
+from numpy.typing import NDArray
+from numpy.testing import assert_equal
+
+from recOrder.io.utils import ret_ori_overlay
+
+
+@st.composite
+def _birefringence(draw):
+    shape = (2,) + tuple(
+        draw(st.lists(st.integers(1, 16), min_size=2, max_size=4))
+    )
+    dtype = draw(npst.floating_dtypes(sizes=(32, 64)))
+    retardance = draw(
+        npst.arrays(
+            dtype,
+            shape=shape,
+            elements=st.floats(
+                min_value=0,
+                max_value=50,
+                exclude_min=True,
+                width=dtype.itemsize * 8,
+            ),
+        )
+    )
+    orientation = draw(
+        npst.arrays(
+            dtype,
+            shape=shape,
+            elements=st.floats(
+                min_value=0,
+                max_value=dtype.type(np.pi),
+                exclude_min=True,
+                exclude_max=True,
+                width=dtype.itemsize * 8,
+            ),
+        )
+    )
+    return retardance, orientation
+
+
+@given(briefringence=_birefringence(), jch=st.booleans())
+def test_ret_ori_overlay(briefringence: tuple[NDArray, NDArray], jch: bool):
+    """Test recOrder.io.utils.ret_ori_overlay()"""
+    retardance, orientation = briefringence
+    retardance_copy = retardance.copy()
+    orientation_copy = orientation.copy()
+    cmap = "JCh" if jch else "HSV"
+    overlay = ret_ori_overlay(
+        retardance,
+        orientation,
+        ret_max=np.percentile(retardance, 99),
+        cmap=cmap,
+    )
+    # check that the function did not mutate input data
+    assert_equal(retardance, retardance_copy)
+    assert_equal(orientation, orientation_copy)
+    # check output properties
+    # output contains NaN, pending further investigation
+    # assert overlay.min() >= 0
+    # assert overlay.max() <= 1
+    assert overlay.shape == retardance.shape + (3,)

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,6 +59,7 @@ dev =
 	tox
 	pre-commit
 	black
+	hypothesis
 
 [options.package_data]
 * = *.yaml


### PR DESCRIPTION
Fix #348.

Currently this does not delay the compute and brings all the data into memory. So it will NOT work with large datasets.

Making it work lazily through Dask needs some changes to the overlay rendering function, which uses `np.copy()` that is not supported by Dask arrays.