### PR TITLE
Multiple birefringence overlays

### DIFF
--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -1181,7 +1181,9 @@ class MainWidget(QWidget):
                         "Detected updated birefringence layers: "
                         f"'{latest_layer_name}', '{other_name}'"
                     )
-                    self._draw_bire_overlay(overlay_name)
+                    self._draw_bire_overlay(
+                        [ch + suffix, other_name], overlay_name
+                    )
         if latest_layer_name == channels[1]:
             logging.info(
                 "Detected orientation layer in updated layer list."
@@ -1189,15 +1191,17 @@ class MainWidget(QWidget):
             )
             self.viewer.layers[channels[1]].colormap = "hsv"
 
-    def _draw_bire_overlay(self, name: str):
+    def _draw_bire_overlay(
+        self, source_names: list[str, str], overlay_name: str
+    ):
         def _layer_data(name: str):
             return self.viewer.layers[name].data
 
         def _draw(overlay):
-            self._add_or_update_image_layer(overlay, name, cmap="rgb")
+            self._add_or_update_image_layer(overlay, overlay_name, cmap="rgb")
 
-        retardance = _layer_data("Retardance")
-        orientation = _layer_data("Orientation")
+        retardance = _layer_data(sorted(source_names)[1])
+        orientation = _layer_data(sorted(source_names)[0])
         worker = create_worker(
             ret_ori_overlay,
             retardance=retardance,

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -1195,9 +1195,9 @@ class MainWidget(QWidget):
 
         def _draw(overlay):
             self._add_or_update_image_layer(overlay, overlay_name, cmap="rgb")
-
-        retardance = _layer_data(sorted(source_names)[1])
-        orientation = _layer_data(sorted(source_names)[0])
+        orientation_name, retardance_name = sorted(source_names)
+        retardance = _layer_data(retardance_name)
+        orientation = _layer_data(orientation_name)
         worker = create_worker(
             ret_ori_overlay,
             retardance=retardance,

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -1189,7 +1189,7 @@ class MainWidget(QWidget):
                 "Detected orientation layer in updated layer list."
                 "Setting its colormap to HSV."
             )
-            self.viewer.layers[channels[1]].colormap = "hsv"
+            self.viewer.layers[latest_layer_name].colormap = "hsv"
 
     def _draw_bire_overlay(
         self, source_names: list[str, str], overlay_name: str

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -1163,10 +1163,6 @@ class MainWidget(QWidget):
             value[1], "Background Orientation", cmap="hsv"
         )
 
-    @staticmethod
-    def _match_layer_list(source: LayerList, pattern: str):
-        return [layer.name for layer in source if layer.name == pattern]
-
     def handle_layers_updated(self, event: Event):
         layers: LayerList = event.source
         latest_layer_name = layers[-1].name

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -1181,7 +1181,7 @@ class MainWidget(QWidget):
                         "Detected updated birefringence layers: "
                         f"'{latest_layer_name}', '{other_name}'"
                     )
-                    self._draw_bire_overlay()
+                    self._draw_bire_overlay(overlay_name)
         if latest_layer_name == channels[1]:
             logging.info(
                 "Detected orientation layer in updated layer list."

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -1184,7 +1184,7 @@ class MainWidget(QWidget):
                     self._draw_bire_overlay(
                         [ch + suffix, other_name], overlay_name
                     )
-        if latest_layer_name == channels[1]:
+        if latest_layer_name.startswith(channels[1]):
             logging.info(
                 "Detected orientation layer in updated layer list."
                 "Setting its colormap to HSV."

--- a/recOrder/tests/util_tests/test_overlays.py
+++ b/recOrder/tests/util_tests/test_overlays.py
@@ -14,6 +14,7 @@ def _birefringence(draw):
         draw(st.lists(st.integers(1, 16), min_size=2, max_size=4))
     )
     dtype = draw(npst.floating_dtypes(sizes=(32, 64)))
+    bit_width = dtype.itemsize * 8
     retardance = draw(
         npst.arrays(
             dtype,
@@ -22,7 +23,7 @@ def _birefringence(draw):
                 min_value=0,
                 max_value=50,
                 exclude_min=True,
-                width=dtype.itemsize * 8,
+                width=bit_width,
             ),
         )
     )
@@ -35,7 +36,7 @@ def _birefringence(draw):
                 max_value=dtype.type(np.pi),
                 exclude_min=True,
                 exclude_max=True,
-                width=dtype.itemsize * 8,
+                width=bit_width,
             ),
         )
     )


### PR DESCRIPTION
Implements https://github.com/mehta-lab/recOrder/pull/357#issuecomment-1526522379.

This works on a best-effort basis. If the user deletes part of the layer list (e.g. keeping orientation but not retardance) and loads another dataset, this will produce wrong overlays.

Also this treats any layer whose name ***starts with*** 'Retardance' and 'Orientation' as a birefringence layer. So layers with names like 'Retardance-mask' and 'Orientation of the fish body axis' will also be treated as birefringence layers and cause errors.