### PR TITLE
Upgrade pycromanager to 0.27.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ setup_requires = setuptools_scm
 # add your package requirements here
 install_requires =
 	waveorder==1.0.0rc0
-	pycromanager==0.25.40
+	pycromanager==0.27.2
 	click>=8.0.1
 	natsort>=7.1.1
 	colorspacious>=1.1.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ setup_requires = setuptools_scm
 # add your package requirements here
 install_requires =
 	waveorder==1.0.0rc0
-	pycromanager==0.24.1
+	pycromanager==0.25.40
 	click>=8.0.1
 	natsort>=7.1.1
 	colorspacious>=1.1.2


### PR DESCRIPTION
- @ieivanov requested that we bump recOrder's pycromanager dependency to support some of the features that mantis needs. 
- I tested 0.25.40 (matching mantis' depenedency), and found that it had issues with multithreading: see https://github.com/micro-manager/pycro-manager/issues/555 and fix https://github.com/micro-manager/pycro-manager/pull/558
- I tested the pycromanager release 0.27.2 (the release before our current MM release 2023-04-26), and found it's working well. 
- I tested the latest pycromanager release 0.27.5, and found that the ZMQ version has been bumped, so we'll need to upgrade it at the same time as MM. This can happen later. 