### PR TITLE
Remove assertion and unused function

### DIFF
--- a/recOrder/calib/Calibration.py
+++ b/recOrder/calib/Calibration.py
@@ -106,17 +106,18 @@ class QLIPP_Calibration:
         # Set Mode
         # TODO: make sure LC or TriggerScope are loaded in the respective modes
         allowed_modes = ["MM-Retardance", "MM-Voltage", "DAC"]
-        assert (
-            lc_control_mode in allowed_modes
-        ), f"LC control mode must be one of {allowed_modes}"
+        if lc_control_mode not in allowed_modes:
+            raise ValueError(f"LC control mode must be one of {allowed_modes}")
         self.mode = lc_control_mode
         self.LC_DAC_conversion = 4  # convert between the input range of LCs (0-20V) and the output range of the DAC (0-5V)
 
         # Initialize calibration class
         allowed_interp_methods = ["schnoor_fit", "linear"]
-        assert (
-            interp_method in allowed_interp_methods
-        ), f"LC calibration data interpolation method must be one of {allowed_interp_methods}"
+        if interp_method not in allowed_interp_methods:
+            raise ValueError(
+                "LC calibration data interpolation method must be one of "
+                f"{allowed_interp_methods}"
+            )
         dir_path = mmc.getDeviceAdapterSearchPaths().get(
             0
         )  # MM device adapter directory

--- a/recOrder/io/utils.py
+++ b/recOrder/io/utils.py
@@ -72,48 +72,6 @@ class MockEmitter:
         pass
 
 
-def get_unimodal_threshold(input_image):
-    """Determines optimal unimodal threshold
-    https://users.cs.cf.ac.uk/Paul.Rosin/resources/papers/unimodal2.pdf
-    https://www.mathworks.com/matlabcentral/fileexchange/45443-rosin-thresholding
-    :param np.array input_image: generate mask for this image
-    :return float best_threshold: optimal lower threshold for the foreground
-     hist
-    """
-
-    hist_counts, bin_edges = np.histogram(
-        input_image,
-        bins=256,
-        range=(input_image.min(), np.percentile(input_image, 99.5)),
-    )
-    bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2
-
-    # assuming that background has the max count
-    max_idx = np.argmax(hist_counts)
-    int_with_max_count = bin_centers[max_idx]
-    p1 = [int_with_max_count, hist_counts[max_idx]]
-
-    # find last non-empty bin
-    pos_counts_idx = np.where(hist_counts > 0)[0]
-    last_binedge = pos_counts_idx[-1]
-    p2 = [bin_centers[last_binedge], hist_counts[last_binedge]]
-
-    best_threshold = -np.inf
-    max_dist = -np.inf
-    for idx in range(max_idx, last_binedge, 1):
-        x0 = bin_centers[idx]
-        y0 = hist_counts[idx]
-        a = [p1[0] - p2[0], p1[1] - p2[1]]
-        b = [x0 - p2[0], y0 - p2[1]]
-        cross_ab = a[0] * b[1] - b[0] * a[1]
-        per_dist = np.linalg.norm(cross_ab) / np.linalg.norm(a)
-        if per_dist > max_dist:
-            best_threshold = x0
-            max_dist = per_dist
-    assert best_threshold > -np.inf, "Error in unimodal thresholding"
-    return best_threshold
-
-
 def ram_message():
     """
     Determine if the system's RAM capacity is sufficient for running reconstruction.


### PR DESCRIPTION
Fix #213.

Also remove the orphaned `get_unimodal_threshold` function. This was likely used for segmentation (e.g. finding nuclei mask) and is now part of other analysis pipelines. We can also add a deprecation warning instead of removal for 0.4.0 if anyone is potentially still using it from here.