### PR TITLE
Live reconstruction compatibility features

### DIFF
--- a/examples/birefringence-and-phase.yml
+++ b/examples/birefringence-and-phase.yml
@@ -3,6 +3,7 @@ input_channel_names:
 - State1
 - State2
 - State3
+time_indices: all
 reconstruction_dimension: 3
 birefringence:
   transfer_function:

--- a/examples/birefringence.yml
+++ b/examples/birefringence.yml
@@ -3,6 +3,7 @@ input_channel_names:
 - State1
 - State2
 - State3
+time_indices: all
 reconstruction_dimension: 3
 birefringence:
   transfer_function:

--- a/examples/fluorescence.yml
+++ b/examples/fluorescence.yml
@@ -1,5 +1,6 @@
 input_channel_names:
 - GFP
+time_indices: all
 reconstruction_dimension: 3
 fluorescence:
   transfer_function:

--- a/examples/phase.yml
+++ b/examples/phase.yml
@@ -1,5 +1,6 @@
 input_channel_names:
 - BF
+time_indices: all
 reconstruction_dimension: 3
 phase:
   transfer_function:

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -19,6 +19,21 @@ from waveorder.models import (
 )
 
 
+def _load_configuration_settings(
+    configuration_settings: Union[str, ReconstructionSettings]
+) -> ReconstructionSettings:
+    if isinstance(configuration_settings, str):
+        return utils.yaml_to_model(
+            configuration_settings, ReconstructionSettings
+        )
+    elif isinstance(configuration_settings, ReconstructionSettings):
+        return configuration_settings
+    else:
+        raise ValueError(
+            f"configuration_settings = {configuration_settings} must be a string or a ReconstructionSettings object."
+        )
+
+
 def _check_background_consistency(background_shape, data_shape):
     data_cyx_shape = (data_shape[1],) + data_shape[3:]
     if background_shape != data_cyx_shape:
@@ -60,16 +75,7 @@ def apply_inverse_transfer_function_cli(
     input_dataset = open_ome_zarr(input_data_path)
 
     # Load configuration settings file
-    if isinstance(configuration_settings, str):
-        settings = utils.yaml_to_model(
-            configuration_settings, ReconstructionSettings
-        )
-    elif isinstance(configuration_settings, ReconstructionSettings):
-        settings = configuration_settings
-    else:
-        raise ValueError(
-            f"configuration_settings = {configuration_settings} must be a string or a ReconstructionSettings object."
-        )
+    settings = _load_configuration_settings(configuration_settings)
 
     # Check input channel names
     if not set(settings.input_channel_names).issubset(

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -68,6 +68,13 @@ def apply_inverse_transfer_function_cli(
             f"time_indices = {time_indices} should be `all`, a list of integers, or an integer."
         )
 
+    # Check for invalid times
+    if np.max(time_indices) > input_dataset.data.shape[0]:
+        ValueError(
+            f"time_indices = {time_indices} includes a time index beyond the size the of the dataset = {input_dataset.data.shape[0]}"
+        )
+
+
     # Simplify important settings names
     recon_biref = settings.birefringence is not None
     recon_phase = settings.phase is not None

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -144,26 +144,29 @@ def apply_inverse_transfer_function_cli(
         output_z_shape = input_dataset.data.shape[2]
 
     output_shape = (
-        t_shape,
+        input_dataset.data.shape[0],
         len(channel_names),
         output_z_shape,
     ) + input_dataset.data.shape[3:]
 
     # Create output dataset
     output_dataset = open_ome_zarr(
-        output_path, layout="fov", mode="w", channel_names=channel_names
+        output_path, layout="fov", mode="a", channel_names=channel_names
     )
-    output_array = output_dataset.create_zeros(
-        name="0",
-        shape=output_shape,
-        dtype=np.float32,
-        chunks=(
-            1,
-            1,
-            1,
+    if 0 in time_indices:
+        output_array = output_dataset.create_zeros(
+            name="0",
+            shape=output_shape,
+            dtype=np.float32,
+            chunks=(
+                1,
+                1,
+                1,
+            )
+            + input_dataset.data.shape[3:],  # chunk by YX
         )
-        + input_dataset.data.shape[3:],  # chunk by YX
-    )
+    else:
+        output_array = output_dataset[0]
 
     # Load data
     tczyx_uint16_numpy = input_dataset.data.oindex[:, channel_indices]

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -53,8 +53,20 @@ def apply_inverse_transfer_function_cli(
             input_dataset.channel_names.index(input_channel_name)
         )
 
-    # Load dataset shape
-    t_shape = input_dataset.data.shape[0]
+    # Find time indices
+    if settings.time_indices == "all":
+        time_indices = range(input_dataset.data.shape[0])
+        t_shape = input_dataset.data.shape[0]
+    elif isinstance(settings.time_indices, list):
+        time_indices = settings.time_indices
+        t_shape = len(time_indices)
+    elif isinstance(settings.time_indices, int):
+        time_indices = [settings.time_indices]
+        t_shape = 1
+    else:
+        ValueError(
+            f"time_indices = {time_indices} should be `all`, a list of integers, or an integer."
+        )
 
     # Simplify important settings names
     recon_biref = settings.birefringence is not None
@@ -143,7 +155,7 @@ def apply_inverse_transfer_function_cli(
             transfer_function_dataset["intensity_to_stokes_matrix"][0, 0, 0]
         )
 
-        for time_index in range(t_shape):
+        for time_index in time_indices:
             # Apply
             reconstructed_parameters = (
                 inplane_oriented_thick_pol3d.apply_inverse_transfer_function(
@@ -180,7 +192,7 @@ def apply_inverse_transfer_function_cli(
                 transfer_function_dataset["phase_transfer_function"][0, 0]
             )
 
-            for time_index in range(t_shape):
+            for time_index in time_indices:
                 # Apply
                 (
                     _,
@@ -210,7 +222,7 @@ def apply_inverse_transfer_function_cli(
             )
 
             # Apply
-            for time_index in range(t_shape):
+            for time_index in time_indices:
                 zyx_phase = phase_thick_3d.apply_inverse_transfer_function(
                     tczyx_data[time_index, 0],
                     real_potential_transfer_function,
@@ -246,7 +258,7 @@ def apply_inverse_transfer_function_cli(
                 transfer_function_dataset["phase_transfer_function"][0, 0]
             )
 
-            for time_index in range(t_shape):
+            for time_index in time_indices:
                 # Apply
                 reconstructed_parameters_2d = inplane_oriented_thick_pol3d.apply_inverse_transfer_function(
                     tczyx_data[time_index],
@@ -304,7 +316,7 @@ def apply_inverse_transfer_function_cli(
             )
 
             # Apply
-            for time_index in range(t_shape):
+            for time_index in time_indices:
                 reconstructed_parameters_3d = inplane_oriented_thick_pol3d.apply_inverse_transfer_function(
                     tczyx_data[time_index],
                     intensity_to_stokes_matrix,
@@ -348,7 +360,7 @@ def apply_inverse_transfer_function_cli(
             )
 
             # Apply
-            for time_index in range(t_shape):
+            for time_index in time_indices:
                 zyx_recon = isotropic_fluorescent_thick_3d.apply_inverse_transfer_function(
                     tczyx_data[time_index, 0],
                     optical_transfer_function,

--- a/recOrder/cli/settings.py
+++ b/recOrder/cli/settings.py
@@ -9,7 +9,7 @@ from pydantic import (
     root_validator,
     validator,
 )
-from typing import Literal, List, Optional
+from typing import Literal, List, Optional, Union
 
 # This file defines the configuration settings for the CLI.
 
@@ -148,6 +148,9 @@ class FluorescenceSettings(MyBaseModel):
 # Top level settings
 class ReconstructionSettings(MyBaseModel):
     input_channel_names: List[str] = [f"State{i}" for i in range(4)]
+    time_indices: Union[
+        NonNegativeInt, List[NonNegativeInt], Literal["all"]
+    ] = "all"
     reconstruction_dimension: Literal[2, 3] = 3
     birefringence: Optional[BirefringenceSettings]
     phase: Optional[PhaseSettings]

--- a/recOrder/tests/cli_tests/test_reconstruct.py
+++ b/recOrder/tests/cli_tests/test_reconstruct.py
@@ -99,7 +99,9 @@ def test_reconstruct(tmp_path):
 
         # Check output
         result_dataset = open_ome_zarr(result_path)
-        assert result_dataset["0"].shape[0] in {1, 2}
+        t_opt = len(list(time_indices))
+        time_dim = t_opt if t_opt >= 2 else 1
+        assert result_dataset["0"].shape[0] == time_dim
         assert result_dataset["0"].shape[3:] == (5, 6)
 
         # Test direct recon

--- a/recOrder/tests/cli_tests/test_reconstruct.py
+++ b/recOrder/tests/cli_tests/test_reconstruct.py
@@ -23,11 +23,13 @@ def test_reconstruct(tmp_path):
     birefringence_settings = settings.BirefringenceSettings(
         transfer_function=settings.BirefringenceTransferFunctionSettings()
     )
+
+    # birefringence_option, time_indices, phase_option, dimension_option, time_length_target
     all_options = [
-        (birefringence_settings, [0], None, 2),
-        (birefringence_settings, 0, settings.PhaseSettings(), 2),
-        (birefringence_settings, [0, 1], None, 3),
-        (birefringence_settings, "all", settings.PhaseSettings(), 3),
+        (birefringence_settings, [0], None, 2, 1),
+        (birefringence_settings, 0, settings.PhaseSettings(), 2, 1),
+        (birefringence_settings, [0, 1], None, 3, 2),
+        (birefringence_settings, "all", settings.PhaseSettings(), 3, 2),
     ]
 
     for (
@@ -35,6 +37,7 @@ def test_reconstruct(tmp_path):
         time_indices,
         phase_option,
         dimension_option,
+        time_length_target,
     ) in all_options:
         if (birefringence_option is None) and (phase_option is None):
             continue
@@ -99,9 +102,7 @@ def test_reconstruct(tmp_path):
 
         # Check output
         result_dataset = open_ome_zarr(result_path)
-        t_opt = len(list(time_indices))
-        time_dim = t_opt if t_opt >= 2 else 1
-        assert result_dataset["0"].shape[0] == time_dim
+        assert result_dataset["0"].shape[0] == time_length_target
         assert result_dataset["0"].shape[3:] == (5, 6)
 
         # Test direct recon

--- a/recOrder/tests/cli_tests/test_reconstruct.py
+++ b/recOrder/tests/cli_tests/test_reconstruct.py
@@ -1,6 +1,6 @@
 import numpy as np
 from recOrder.cli.main import cli
-from recOrder.cli import settings
+from recOrder.cli import settings, apply_inverse_transfer_function
 from recOrder.io import utils
 from click.testing import CliRunner
 from iohub.ngff import open_ome_zarr
@@ -67,7 +67,7 @@ def test_reconstruct(tmp_path):
         )
         assert tf_path.exists()
 
-        # Apply the tf
+        # Apply the tf via CLI
         result_path = input_path.with_name("result.zarr")
 
         result_inv = runner.invoke(
@@ -86,6 +86,16 @@ def test_reconstruct(tmp_path):
         assert result_path.exists()
         assert result_inv.exit_code == 0
         assert "Reconstructing" in result_inv.output
+
+        # Apply the tf function call directly
+        result_path_direct = input_path.with_name("result.zarr")
+        apply_inverse_transfer_function.apply_inverse_transfer_function_cli(
+            str(input_path),
+            str(tf_path),
+            recon_settings,
+            str(result_path_direct),
+        )
+        assert result_path_direct.exists()
 
         # Check output
         result_dataset = open_ome_zarr(result_path)


### PR DESCRIPTION
This PR adds two features to make `recOrder`'s CLI reconstruction workflow more compatible with live reconstructions:

1. a new `time_indices` option for reconstructing a subset of all time points. `time_indices` can be an integer, a list of integers, or `all` (default). This allows the user to reconstruct all time points (typical for offline), or individual time points (typical for faster online reconstructions). 

2. support for passing `ReconstructionSettings` objects directly into `apply_inverse_transfer_function_cli`. This feature makes it more convenient for an online reconstruction routine to call the same reconstruction on different time points...instead of modifying and save a configuration yaml file for each time point, the user can modify the `time_indices` attribute of the `ReconstructionSettings` object directly. 

@ziw-liu I'm not sure if I implemented (2) in the way that you had in mind...please suggest improvements. 
@clinton-huynh please feel free to add or modify this branch. 