### PR TITLE
Bump dependencies and enable widget test

### DIFF
--- a/recOrder/tests/widget_tests/test_dock_widget.py
+++ b/recOrder/tests/widget_tests/test_dock_widget.py
@@ -1,17 +1,8 @@
-import sys
-import os
-
-import pytest
 from napari.viewer import ViewerModel
 
 from recOrder.plugin.main_widget import MainWidget
 
 
-# FIXME: Linux Qt platform in GitHub actions
-@pytest.mark.skipif(
-    bool("linux" in sys.platform and os.environ.get("CI")),
-    reason="Qt on Linux CI runners does not work",
-)
 def test_dock_widget(make_napari_viewer):
     viewer: ViewerModel = make_napari_viewer()
     viewer.window.add_dock_widget(MainWidget(viewer))

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
 	napari-ome-zarr>=0.3.2 # drag and drop convenience
 	napari[pyqt6_experimental]
 	importlib-metadata
-	iohub==0.1.0.dev3
+	iohub==0.1.0.dev4
 	
 [options.extras_require]
 dev =

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,6 @@ packages = find:
 include_package_data = True
 python_requires = >=3.9
 setup_requires = setuptools_scm
-# add your package requirements here
 install_requires =
 	waveorder==2.0.0rc1
 	pycromanager==0.27.2
@@ -43,9 +42,7 @@ install_requires =
 	colorspacious>=1.1.2
 	pyqtgraph>=0.12.3
 	napari-ome-zarr>=0.3.2 # drag and drop convenience
-	napari[all];'arm64' not in platform_machine # with Qt5 and skimage
-	napari;'arm64' in platform_machine # without Qt and skimage
-	PyQt6;'arm64' in platform_machine
+	napari[pyqt6_experimental]
 	importlib-metadata
 	iohub==0.1.0.dev3
 	


### PR DESCRIPTION
### Dependencies

- With napari 4.18, Qt6 is now an explicit option, so we can remove the workaround added for #193.
- Bumping iohub to v0.1.0dev4

### Enable GUI test

- With the Qt change, the dock widget test is now passing on Linux CI runners too.