### PR TITLE
0.3.1 documentation patch

### DIFF
--- a/docs/meadowlark-software-upgrade.md
+++ b/docs/meadowlark-software-upgrade.md
@@ -1,8 +1,0 @@
-# Upgrade Meadownlark PC software version
-
-To upgrade your "PC software version" use these steps:
-
-- From "Add and remove programs", remove CellDrive5000 and "National Instruments Software".
-- From "Device manager", open the "Meadowlark Optics" group, right click `mlousb`, click "Uninstall device", check "Delete the driver software for this device", and click "Uninstall". Uninstall `Meadowlark Optics D5020 LC Driver` following the same steps.
-- Using the USB stick provided by Meadowlark, reinstall the USB drivers and CellDrive5000. 
-- **Upgrading users:** you will need to reinstall the Meadowlark device to your micromanager configuration file, because the device driver's name has changed to `MeadowlarkLC`. 

--- a/docs/meadowlark-software-upgrade.md
+++ b/docs/meadowlark-software-upgrade.md
@@ -1,0 +1,9 @@
+# Upgrade Meadownlark PC software version
+
+To upgrade your "PC software version" use these steps:
+
+- From "Add and remove programs", remove CellDrive5000 and "National Instruments Software".
+- From "Device manager", open the "Meadowlark Optics" group, right click `mlousb`, click "Uninstall device", check "Delete the driver software for this device", and click "Uninstall". Uninstall `Meadowlark Optics D5020 LC Driver` following the same steps.
+- Using the USB stick provided by Meadowlark, reinstall the USB drivers and CellDrive5000. 
+- Confirm that "PC software version" == 1.08
+- **Upgrading users:** you will need to reinstall the Meadowlark device to your micromanager configuration file, because the device driver's name has changed to `MeadowlarkLC`. 

--- a/docs/meadowlark-software-upgrade.md
+++ b/docs/meadowlark-software-upgrade.md
@@ -5,5 +5,4 @@ To upgrade your "PC software version" use these steps:
 - From "Add and remove programs", remove CellDrive5000 and "National Instruments Software".
 - From "Device manager", open the "Meadowlark Optics" group, right click `mlousb`, click "Uninstall device", check "Delete the driver software for this device", and click "Uninstall". Uninstall `Meadowlark Optics D5020 LC Driver` following the same steps.
 - Using the USB stick provided by Meadowlark, reinstall the USB drivers and CellDrive5000. 
-- Confirm that "PC software version" == 1.08
 - **Upgrading users:** you will need to reinstall the Meadowlark device to your micromanager configuration file, because the device driver's name has changed to `MeadowlarkLC`. 

--- a/docs/microscope-installation-guide.md
+++ b/docs/microscope-installation-guide.md
@@ -25,7 +25,10 @@ Start by installing the Meadowlark DS5020 and liquid crystals using the software
 
 **Check your installation's versions** by opening CellDrive5000 and double clicking the Meadowlark Optics logo. Confirm that **"PC software version = 1.04" and "Controller firmware version >= 1.04".** 
 
-If you need to upgrade your Meadowlark Software, [follow these steps](./meadowlark-software-upgrade.md). 
+If you need to change your PC software version, follow these steps:
+- From "Add and remove programs", remove CellDrive5000 and "National Instruments Software".
+- From "Device manager", open the "Meadowlark Optics" group, right click `mlousb`, click "Uninstall device", check "Delete the driver software for this device", and click "Uninstall". Uninstall `Meadowlark Optics D5020 LC Driver` following the same steps.
+- Using the USB stick provided by Meadowlark, reinstall the USB drivers and CellDrive5000. 
 
 ## Install recOrder software
 

--- a/docs/microscope-installation-guide.md
+++ b/docs/microscope-installation-guide.md
@@ -3,9 +3,9 @@
 This guide will walk through a complete recOrder installation consisting of:
 1. Checking pre-requisites for compatibility. 
 2. Installing Meadowlark DS5020 and liquid crystals.
-1. Installing and launching the latest stable version of `recOrder` via `pip`. 
-2. Installing a compatible version of `MicroManager` and LC device drivers.
-3. Connecting `recOrder` to `MicroManager` via a `pycromanager` connection.
+3. Installing and launching the latest stable version of `recOrder` via `pip`. 
+4. Installing a compatible version of `MicroManager` and LC device drivers.
+5. Connecting `recOrder` to `MicroManager` via a `pycromanager` connection.
 
 # Compatibility Summary 
 Before you start you will need to confirm that your system is compatible with the following software:

--- a/docs/microscope-installation-guide.md
+++ b/docs/microscope-installation-guide.md
@@ -1,11 +1,31 @@
 # Microscope Installation Guide
 
 This guide will walk through a complete recOrder installation consisting of:
+1. Checking pre-requisites for compatibility. 
+2. Installing Meadowlark DS5020 and liquid crystals.
 1. Installing and launching the latest stable version of `recOrder` via `pip`. 
 2. Installing a compatible version of `MicroManager` and LC device drivers.
 3. Connecting `recOrder` to `MicroManager` via a `pycromanager` connection.
 
-Before you start you will need a machine with Windows 10, a Meadowlark DS5020 connected to a liquid crystal device, and a microscope system compatible with `Micromanager`. 
+# Compatibility Summary 
+Before you start you will need to confirm that your system is compatible with the following software:
+
+| Software | Version |  
+| :--- | :--- |
+| `recOrder` | 0.3.x |
+| OS | Windows 10 | 
+| Micromanager version | [2022-09-20 (160 MB)](https://download.micro-manager.org/nightly/2.0/Windows/MMSetup_64bit_2.0.1_20220920.exe) | 
+| Meadowlark drivers | [recOrder-0.3.0-device-drivers.zip (112 kB)](https://github.com/mehta-lab/recOrder/releases/download/0.3.0/recOrder-0.3.0-device-drivers.zip) | 
+| Meadowlark PC software version | 1.04 | 
+| Meadowlark controller firmware version | >=1.04 | 
+
+## Install Meadowlark DS5020 and liquid crystals
+
+Start by installing the Meadowlark DS5020 and liquid crystals using the software on the USB stick provided by Meadowlark. You will need to install the USB drivers and CellDrive5000.
+
+**Check your installation's versions** by opening CellDrive5000 and double clicking the Meadowlark Optics logo. Confirm that **"PC software version = 1.08" and "Controller firmware version = 1.04".** 
+
+If you need to upgrade your Meadowlark Software, [follow these steps](./meadowlark-software-upgrade.md). 
 
 ## Install recOrder software
 
@@ -31,7 +51,7 @@ Install `Micromanager 2.0` nightly build `20220920` (https://micro-manager.org/M
 
 **Note:** We have tested recOrder with `20220920`, but most features will work with newer builds. We recommend testing a minimal installation with `20220920` before testing with a different nightly build or additional device drivers. 
 
-Before launching `Micromanager`, download the Meadowlark device adapters and calibration files from the [release page](https://github.com/mehta-lab/recOrder/releases/) and place these three unzipped files into your `Micromanager` folder (likely `C:\Program Files\Micro-Manager` or similar). 
+Before launching `Micromanager`, [download the Meadowlark device adapters and calibration files](https://github.com/mehta-lab/recOrder/releases/download/0.3.0/recOrder-0.3.0-device-drivers.zip) and place these three unzipped files into your `Micromanager` folder (likely `C:\Program Files\Micro-Manager` or similar). 
 
 Launch `Micromanager`, open `Devices > Hardware Configuration Wizard...`, and add the `MeadowlarkLcOpenSource` device to your configuration. Confirm your installation by opening `Devices > Device Property Browser...` and confirming that `MeadowlarkLCOpenSource` properties appear. 
 

--- a/docs/microscope-installation-guide.md
+++ b/docs/microscope-installation-guide.md
@@ -23,7 +23,7 @@ Before you start you will need to confirm that your system is compatible with th
 
 Start by installing the Meadowlark DS5020 and liquid crystals using the software on the USB stick provided by Meadowlark. You will need to install the USB drivers and CellDrive5000.
 
-**Check your installation's versions** by opening CellDrive5000 and double clicking the Meadowlark Optics logo. Confirm that **"PC software version = 1.04" and "Controller firmware version = 1.04".** 
+**Check your installation's versions** by opening CellDrive5000 and double clicking the Meadowlark Optics logo. Confirm that **"PC software version = 1.04" and "Controller firmware version >= 1.04".** 
 
 If you need to upgrade your Meadowlark Software, [follow these steps](./meadowlark-software-upgrade.md). 
 

--- a/docs/microscope-installation-guide.md
+++ b/docs/microscope-installation-guide.md
@@ -7,7 +7,7 @@ This guide will walk through a complete recOrder installation consisting of:
 4. Installing a compatible version of `MicroManager` and LC device drivers.
 5. Connecting `recOrder` to `MicroManager` via a `pycromanager` connection.
 
-# Compatibility Summary 
+## Compatibility Summary 
 Before you start you will need to confirm that your system is compatible with the following software:
 
 | Software | Version |  

--- a/docs/microscope-installation-guide.md
+++ b/docs/microscope-installation-guide.md
@@ -23,7 +23,7 @@ Before you start you will need to confirm that your system is compatible with th
 
 Start by installing the Meadowlark DS5020 and liquid crystals using the software on the USB stick provided by Meadowlark. You will need to install the USB drivers and CellDrive5000.
 
-**Check your installation's versions** by opening CellDrive5000 and double clicking the Meadowlark Optics logo. Confirm that **"PC software version = 1.08" and "Controller firmware version = 1.04".** 
+**Check your installation's versions** by opening CellDrive5000 and double clicking the Meadowlark Optics logo. Confirm that **"PC software version = 1.04" and "Controller firmware version = 1.04".** 
 
 If you need to upgrade your Meadowlark Software, [follow these steps](./meadowlark-software-upgrade.md). 
 


### PR DESCRIPTION
This PR implements some of the decisions we made in #382. 
Note that this PR is against `patch/0.3.x`. See #304 for context about keeping maintenance branches. 

After this PR:
- the 0.3.1 documentation will include a compatibility table
- the 0.3.1 documentation will be synchronized with the 0.4.0 documentation in #395 

After this PR merges I will release 0.3.1 and push to PyPI. 