### PR TITLE
0.4.0 installation documentation

### DIFF
--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -115,3 +115,7 @@ If you would like `git blame` to ignore formatting commits, run this line:
 
 The `\.git-blame-ignore-revs` file contains a list of commit hashes corresponding to formatting commits.
 If you make a formatting commit, please add the commit's hash to this file.
+
+## Pre-release checklist 
+- merge `README.md` figures to `main`, then update the links to point to these uploaded figures. We do not upload figures to PyPI, so without this step the README figure will not appear on PyPI or napari-hub. 
+- update version numbers in [the microscope dependency guide](./microscope-installation-guide.md).

--- a/docs/meadowlark-software-upgrade.md
+++ b/docs/meadowlark-software-upgrade.md
@@ -1,8 +1,0 @@
-# Upgrade Meadownlark PC software version
-
-To upgrade your "PC software version" use these steps:
-
-- From "Add and remove programs", remove CellDrive5000 and "National Instruments Software".
-- From "Device manager", open the "Meadowlark Optics" group, right click `mlousb`, click "Uninstall device", check "Delete the driver software for this device", and click "Uninstall". Uninstall `Meadowlark Optics D5020 LC Driver` following the same steps.
-- Using the USB stick provided by Meadowlark, reinstall the USB drivers and CellDrive5000. 
-- **Upgrading users:** you will need to reinstall the Meadowlark device to your micromanager configuration file, because the device driver's name has changed to `MeadowlarkLC`. 

--- a/docs/meadowlark-software-upgrade.md
+++ b/docs/meadowlark-software-upgrade.md
@@ -1,0 +1,8 @@
+# Upgrade Meadownlark PC software version
+
+To upgrade your "PC software version" use these steps:
+
+- From "Add and remove programs", remove CellDrive5000 and "National Instruments Software".
+- From "Device manager", open the "Meadowlark Optics" group, right click `mlousb`, click "Uninstall device", check "Delete the driver software for this device", and click "Uninstall". Uninstall `Meadowlark Optics D5020 LC Driver` following the same steps.
+- Using the USB stick provided by Meadowlark, reinstall the USB drivers and CellDrive5000. 
+- **Upgrading users:** you will need to reinstall the Meadowlark device to your micromanager configuration file, because the device driver's name has changed to `MeadowlarkLC`. 

--- a/docs/microscope-installation-guide.md
+++ b/docs/microscope-installation-guide.md
@@ -17,7 +17,7 @@ Before you start you will need to confirm that your system is compatible with th
 | `recOrder` | 0.4.x |
 | OS | Windows 10 | 
 | Micromanager version | [2023-04-26 (160 MB)](https://download.micro-manager.org/nightly/2.0/Windows/MMSetup_64bit_2.0.1_20230426.exe) | 
-| Meadowlark drivers | TODO [recOrder-0.4.0-device-drivers.zip (XXX kB)]() | 
+| Meadowlark drivers | [USB driver (82 kB)](https://github.com/mehta-lab/recOrder/releases/download/0.4.0rc0/usbdrvd.dll) | 
 | Meadowlark PC software version | 1.08 | 
 | Meadowlark controller firmware version | >=1.04 |
 
@@ -53,7 +53,7 @@ Download and install [`Micromanager 2.0` nightly build `20230426` (~150 MB link)
 
 **Note:** We have tested recOrder with `20230426`, but most features will work with newer builds. We recommend testing a minimal installation with `20230426` before testing with a different nightly build or additional device drivers. 
 
-Before launching `Micromanager`, download the TODO link to [USB driver .dll] and place this file into your `Micromanager` folder (likely `C:\Program Files\Micro-Manager` or similar). 
+Before launching `Micromanager`, download the [USB driver](https://github.com/mehta-lab/recOrder/releases/download/0.4.0rc0/usbdrvd.dll) and place this file into your `Micromanager` folder (likely `C:\Program Files\Micro-Manager` or similar). 
 
 Launch `Micromanager`, open `Devices > Hardware Configuration Wizard...`, and add the `MeadowlarkLcOpenSource` device to your configuration. Confirm your installation by opening `Devices > Device Property Browser...` and confirming that `MeadowlarkLCOpenSource` properties appear. 
 

--- a/docs/microscope-installation-guide.md
+++ b/docs/microscope-installation-guide.md
@@ -47,7 +47,7 @@ Download and install [`Micromanager 2.0` nightly build `20230426` (~150 MB link)
 
 **Note:** We have tested recOrder with `20230426`, but most features will work with newer builds. We recommend testing a minimal installation with `20230426` before testing with a different nightly build or additional device drivers. 
 
-Before launching `Micromanager`, download the USB driver dll from the [release page](https://github.com/mehta-lab/recOrder/releases/) and place this pair of unzipped files into your `Micromanager` folder (likely `C:\Program Files\Micro-Manager` or similar). 
+Before launching `Micromanager`, download the USB driver .dll from the [release page](https://github.com/mehta-lab/recOrder/releases/) and place this file into your `Micromanager` folder (likely `C:\Program Files\Micro-Manager` or similar). 
 
 Launch `Micromanager`, open `Devices > Hardware Configuration Wizard...`, and add the `MeadowlarkLcOpenSource` device to your configuration. Confirm your installation by opening `Devices > Device Property Browser...` and confirming that `MeadowlarkLCOpenSource` properties appear. 
 

--- a/docs/microscope-installation-guide.md
+++ b/docs/microscope-installation-guide.md
@@ -7,7 +7,7 @@ This guide will walk through a complete recOrder installation consisting of:
 4. Installing a compatible version of `MicroManager` and LC device drivers.
 5. Connecting `recOrder` to `MicroManager` via a `pycromanager` connection.
  
-# Compatibility Summary 
+## Compatibility Summary 
 Before you start you will need to confirm that your system is compatible with the following software:
 
 | Software | Version |  

--- a/docs/microscope-installation-guide.md
+++ b/docs/microscope-installation-guide.md
@@ -6,8 +6,7 @@ This guide will walk through a complete recOrder installation consisting of:
 3. Installing and launching the latest stable version of `recOrder` via `pip`. 
 4. Installing a compatible version of `MicroManager` and LC device drivers.
 5. Connecting `recOrder` to `MicroManager` via a `pycromanager` connection.
-
-Before you start you will need a machine with Windows 10, a Meadowlark DS5020 connected to a liquid crystal device, and a microscope system compatible with `Micromanager`. 
+ 
 
 # Compatibility Summary 
 Before you start you will need to confirm that your system is compatible with the following software:

--- a/docs/microscope-installation-guide.md
+++ b/docs/microscope-installation-guide.md
@@ -45,7 +45,7 @@ Check your installation:
 ```
 napari -w recOrder-napari
 ```
-should launch napari (may take 15 seconds on a fresh installation) with the recOrder plugin in "Offline" mode. 
+should launch napari with the recOrder plugin (may take 15 seconds on a fresh installation). 
  
 ## Install and configure `Micromanager`
 

--- a/docs/microscope-installation-guide.md
+++ b/docs/microscope-installation-guide.md
@@ -1,27 +1,33 @@
 # Microscope Installation Guide
 
 This guide will walk through a complete recOrder installation consisting of:
-1. Installing and launching the latest stable version of `recOrder` via `pip`. 
-2. Installing a compatible version of `MicroManager` and LC device drivers.
-3. Connecting `recOrder` to `MicroManager` via a `pycromanager` connection.
+1. Checking pre-requisites for compatibility.
+2. Installing Meadowlark DS5020 and liquid crystals.
+3. Installing and launching the latest stable version of `recOrder` via `pip`. 
+4. Installing a compatible version of `MicroManager` and LC device drivers.
+5. Connecting `recOrder` to `MicroManager` via a `pycromanager` connection.
 
 Before you start you will need a machine with Windows 10, a Meadowlark DS5020 connected to a liquid crystal device, and a microscope system compatible with `Micromanager`. 
+
+# Compatibility Summary 
+Before you start you will need to confirm that your system is compatible with the following software:
+
+| Software | Version |  
+| :--- | :--- |
+| `recOrder` | 0.4.x |
+| OS | Windows 10 | 
+| Micromanager version | [2023-04-26 (160 MB)](https://download.micro-manager.org/nightly/2.0/Windows/MMSetup_64bit_2.0.1_20230426.exe) | 
+| Meadowlark drivers | TODO [recOrder-0.4.0-device-drivers.zip (XXX kB)]() | 
+| Meadowlark PC software version | 1.08 | 
+| Meadowlark controller firmware version | >=1.04 |
 
 ## Install Meadowlark DS5020 and liquid crystals
 
 Start by installing the Meadowlark DS5020 and liquid crystals using the software on the USB stick provided by Meadowlark. You will need to install the USB drivers and CellDrive5000.
 
-**Check your installation versions** by opening CellDrive5000 and double clicking the Meadowlark Optics logo. **We have tested `recOrder == 0.4.0` with "PC software version 1.08" and "Controller firmware version 1.04",** and you will need to upgrade if your software and firmware versions are older. 
+**Check your installation versions** by opening CellDrive5000 and double clicking the Meadowlark Optics logo. Confirm that **"PC software version = 1.08" and "Controller firmware version = 1.04".**
 
-To upgrade your "PC software version" use these steps:
-
-- From "Add and remove programs", remove CellDrive5000 and "National Instruments Software".
-- From "Device manager", open the "Meadowlark Optics" group, right click `mlousb`, click "Uninstall device", check "Delete the driver software for this device", and click "Uninstall". Uninstall `Meadowlark Optics D5020 LC Driver` following the same steps.
-- Using the USB stick provided by Meadowlark, reinstall the USB drivers and CellDrive5000. 
-- Confirm that "PC software version" == 1.08
-- **Upgrading users:** you will need to reinstall the Meadowlark device to your micromanager configuration file, because the device driver's name has changed to `MeadowlarkLC`. 
-
-To upgrade your DS5020's firmware, use Meadowlark's "Firmware Updater".
+If you need to upgrade your Meadowlark Software, [follow these steps](./meadowlark-software-upgrade.md). 
 
 ## Install recOrder software
 
@@ -47,7 +53,7 @@ Download and install [`Micromanager 2.0` nightly build `20230426` (~150 MB link)
 
 **Note:** We have tested recOrder with `20230426`, but most features will work with newer builds. We recommend testing a minimal installation with `20230426` before testing with a different nightly build or additional device drivers. 
 
-Before launching `Micromanager`, download the USB driver .dll from the [release page](https://github.com/mehta-lab/recOrder/releases/) and place this file into your `Micromanager` folder (likely `C:\Program Files\Micro-Manager` or similar). 
+Before launching `Micromanager`, download the TODO link to [USB driver .dll] and place this file into your `Micromanager` folder (likely `C:\Program Files\Micro-Manager` or similar). 
 
 Launch `Micromanager`, open `Devices > Hardware Configuration Wizard...`, and add the `MeadowlarkLcOpenSource` device to your configuration. Confirm your installation by opening `Devices > Device Property Browser...` and confirming that `MeadowlarkLCOpenSource` properties appear. 
 

--- a/docs/microscope-installation-guide.md
+++ b/docs/microscope-installation-guide.md
@@ -7,7 +7,6 @@ This guide will walk through a complete recOrder installation consisting of:
 4. Installing a compatible version of `MicroManager` and LC device drivers.
 5. Connecting `recOrder` to `MicroManager` via a `pycromanager` connection.
  
-
 # Compatibility Summary 
 Before you start you will need to confirm that your system is compatible with the following software:
 

--- a/docs/microscope-installation-guide.md
+++ b/docs/microscope-installation-guide.md
@@ -25,7 +25,10 @@ Start by installing the Meadowlark DS5020 and liquid crystals using the software
 
 **Check your installation versions** by opening CellDrive5000 and double clicking the Meadowlark Optics logo. Confirm that **"PC software version = 1.08" and "Controller firmware version >= 1.04".**
 
-If you need to upgrade your Meadowlark Software, [follow these steps](./meadowlark-software-upgrade.md). 
+If you need to change your PC software version, follow these steps:
+- From "Add and remove programs", remove CellDrive5000 and "National Instruments Software".
+- From "Device manager", open the "Meadowlark Optics" group, right click `mlousb`, click "Uninstall device", check "Delete the driver software for this device", and click "Uninstall". Uninstall `Meadowlark Optics D5020 LC Driver` following the same steps.
+- Using the USB stick provided by Meadowlark, reinstall the USB drivers and CellDrive5000. 
 
 ## Install recOrder software
 
@@ -53,10 +56,12 @@ Download and install [`Micromanager 2.0` nightly build `20230426` (~150 MB link)
 
 Before launching `Micromanager`, download the [USB driver](https://github.com/mehta-lab/recOrder/releases/download/0.4.0rc0/usbdrvd.dll) and place this file into your `Micromanager` folder (likely `C:\Program Files\Micro-Manager` or similar). 
 
-Launch `Micromanager`, open `Devices > Hardware Configuration Wizard...`, and add the `MeadowlarkLcOpenSource` device to your configuration. Confirm your installation by opening `Devices > Device Property Browser...` and confirming that `MeadowlarkLCOpenSource` properties appear. 
+Launch `Micromanager`, open `Devices > Hardware Configuration Wizard...`, and add the `MeadowlarkLC` device to your configuration. Confirm your installation by opening `Devices > Device Property Browser...` and confirming that `MeadowlarkLC` properties appear. 
+
+**Upgrading users:** you will need to reinstall the Meadowlark device to your micromanager configuration file, because the device driver's name has changed to from `MeadowlarkLcOpenSource` to `MeadowlarkLC`. 
 
 ### Option 1 (recommended): Voltage-mode calibration installation
- Create a new channel group and add the `MeadowlarkLcOpenSource-Voltage (V) LC-A` and `MeadowlarkLcOpenSource-Voltage (V) LC-B` properties. 
+ Create a new channel group and add the `MeadowlarkLC-Voltage (V) LC-A` and `MeadowlarkLC-Voltage (V) LC-B` properties. 
 
 ![](https://github.com/mehta-lab/recOrder/blob/main/docs/images/create_group_voltage.png)
 
@@ -66,11 +71,11 @@ Add 5 presets to this group named `State0`, `State1`, `State2`, `State3`, and `S
 
 ### Option 2 (soon deprecated): retardance mode calibration installation
 
-Create a new channel group and add the property `MeadowlarkLcOpenSource-String send to -`. 
+Create a new channel group and add the property `MeadowlarkLC-String send to -`. 
 
 ![](https://github.com/mehta-lab/recOrder/blob/main/docs/images/create_group.png)
 
-Add 5 presets to this group named `State0`, `State1`, `State2`, `State3`, and `State4` and set the corresponding preset values to `state0`, `state1`, `state2`, `state3`, `state4` in the `MeadowlarkLcOpenSource-String send to –`* property. 
+Add 5 presets to this group named `State0`, `State1`, `State2`, `State3`, and `State4` and set the corresponding preset values to `state0`, `state1`, `state2`, `state3`, `state4` in the `MeadowlarkLC-String send to –`* property. 
 
 ![](https://github.com/mehta-lab/recOrder/blob/main/docs/images/create_preset.png)
 

--- a/docs/microscope-installation-guide.md
+++ b/docs/microscope-installation-guide.md
@@ -23,7 +23,7 @@ Before you start you will need to confirm that your system is compatible with th
 
 Start by installing the Meadowlark DS5020 and liquid crystals using the software on the USB stick provided by Meadowlark. You will need to install the USB drivers and CellDrive5000.
 
-**Check your installation versions** by opening CellDrive5000 and double clicking the Meadowlark Optics logo. Confirm that **"PC software version = 1.08" and "Controller firmware version = 1.04".**
+**Check your installation versions** by opening CellDrive5000 and double clicking the Meadowlark Optics logo. Confirm that **"PC software version = 1.08" and "Controller firmware version >= 1.04".**
 
 If you need to upgrade your Meadowlark Software, [follow these steps](./meadowlark-software-upgrade.md). 
 


### PR DESCRIPTION
Together with #394, fixes #362. 

Replaces #382. 

After this PR the documentation:
- includes a compatibility table
- recommends that the user download the USB driver from a direct link to our github release page. [I've made a test pre-release for this purpose.](https://github.com/mehta-lab/recOrder/releases/tag/0.4.0rc0)
- is synchronized with the documentation in #394, which will appear with the 0.3.1 release