### PR TITLE
Reconstruct a subset of time indices

### DIFF
--- a/examples/birefringence-and-phase.yml
+++ b/examples/birefringence-and-phase.yml
@@ -3,6 +3,7 @@ input_channel_names:
 - State1
 - State2
 - State3
+time_indices: all
 reconstruction_dimension: 3
 birefringence:
   transfer_function:

--- a/examples/birefringence.yml
+++ b/examples/birefringence.yml
@@ -3,6 +3,7 @@ input_channel_names:
 - State1
 - State2
 - State3
+time_indices: all
 reconstruction_dimension: 3
 birefringence:
   transfer_function:

--- a/examples/fluorescence.yml
+++ b/examples/fluorescence.yml
@@ -1,5 +1,6 @@
 input_channel_names:
 - GFP
+time_indices: all
 reconstruction_dimension: 3
 fluorescence:
   transfer_function:

--- a/examples/phase.yml
+++ b/examples/phase.yml
@@ -1,5 +1,6 @@
 input_channel_names:
 - BF
+time_indices: all
 reconstruction_dimension: 3
 phase:
   transfer_function:

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -167,7 +167,7 @@ def apply_inverse_transfer_function_cli(
             transfer_function_dataset["intensity_to_stokes_matrix"][0, 0, 0]
         )
 
-        for output_index, time_index in enumerate(time_indices):
+        for time_index in time_indices:
             # Apply
             reconstructed_parameters = (
                 inplane_oriented_thick_pol3d.apply_inverse_transfer_function(
@@ -180,7 +180,7 @@ def apply_inverse_transfer_function_cli(
             )
             # Save
             for param_index, parameter in enumerate(reconstructed_parameters):
-                output_array[output_index, param_index] = parameter
+                output_array[time_index, param_index] = parameter
 
     # [phase only]
     if recon_phase and (not recon_biref):
@@ -204,7 +204,7 @@ def apply_inverse_transfer_function_cli(
                 transfer_function_dataset["phase_transfer_function"][0, 0]
             )
 
-            for output_index, time_index in enumerate(time_indices):
+            for time_index in time_indices:
                 # Apply
                 (
                     _,
@@ -217,7 +217,7 @@ def apply_inverse_transfer_function_cli(
                 )
 
                 # Save
-                output_array[output_index, -1, 0] = yx_phase
+                output_array[time_index, -1, 0] = yx_phase
 
         # [phase only, 3]
         elif recon_dim == 3:
@@ -234,7 +234,7 @@ def apply_inverse_transfer_function_cli(
             )
 
             # Apply
-            for output_index, time_index in enumerate(time_indices):
+            for time_index in time_indices:
                 zyx_phase = phase_thick_3d.apply_inverse_transfer_function(
                     tczyx_data[time_index, 0],
                     real_potential_transfer_function,
@@ -245,7 +245,7 @@ def apply_inverse_transfer_function_cli(
                     **settings.phase.apply_inverse.dict(),
                 )
                 # Save
-                output_array[output_index, -1] = zyx_phase
+                output_array[time_index, -1] = zyx_phase
 
     # [biref and phase]
     if recon_biref and recon_phase:
@@ -270,7 +270,7 @@ def apply_inverse_transfer_function_cli(
                 transfer_function_dataset["phase_transfer_function"][0, 0]
             )
 
-            for output_index, time_index in enumerate(time_indices):
+            for time_index in time_indices:
                 # Apply
                 reconstructed_parameters_2d = inplane_oriented_thick_pol3d.apply_inverse_transfer_function(
                     tczyx_data[time_index],
@@ -304,8 +304,8 @@ def apply_inverse_transfer_function_cli(
                 for param_index, parameter in enumerate(
                     reconstructed_parameters_2d
                 ):
-                    output_array[output_index, param_index] = parameter
-                output_array[output_index, -1, 0] = yx_phase
+                    output_array[time_index, param_index] = parameter
+                output_array[time_index, -1, 0] = yx_phase
 
         # [biref and phase, 3]
         elif recon_dim == 3:
@@ -328,7 +328,7 @@ def apply_inverse_transfer_function_cli(
             )
 
             # Apply
-            for output_index, time_index in enumerate(time_indices):
+            for time_index in time_indices:
                 reconstructed_parameters_3d = inplane_oriented_thick_pol3d.apply_inverse_transfer_function(
                     tczyx_data[time_index],
                     intensity_to_stokes_matrix,
@@ -352,8 +352,8 @@ def apply_inverse_transfer_function_cli(
                 for param_index, parameter in enumerate(
                     reconstructed_parameters_3d
                 ):
-                    output_array[output_index, param_index] = parameter
-                output_array[output_index, -1] = zyx_phase
+                    output_array[time_index, param_index] = parameter
+                output_array[time_index, -1] = zyx_phase
 
     # [fluo]
     if recon_fluo:
@@ -372,7 +372,7 @@ def apply_inverse_transfer_function_cli(
             )
 
             # Apply
-            for output_index, time_index in enumerate(time_indices):
+            for time_index in time_indices:
                 zyx_recon = isotropic_fluorescent_thick_3d.apply_inverse_transfer_function(
                     tczyx_data[time_index, 0],
                     optical_transfer_function,
@@ -381,7 +381,7 @@ def apply_inverse_transfer_function_cli(
                 )
 
                 # Save
-                output_array[output_index, 0] = zyx_recon
+                output_array[time_index, 0] = zyx_recon
 
     output_dataset.zattrs["settings"] = settings.dict()
 

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -115,7 +115,9 @@ def apply_inverse_transfer_function_cli(
     output_dataset = open_ome_zarr(
         output_path, layout="fov", mode="a", channel_names=channel_names
     )
-    if 0 in time_indices:
+
+    # Create an empty TCZYX array if it doesn't exist
+    if not output_dataset.array_keys():
         output_array = output_dataset.create_zeros(
             name="0",
             shape=output_shape,

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -106,26 +106,29 @@ def apply_inverse_transfer_function_cli(
         output_z_shape = input_dataset.data.shape[2]
 
     output_shape = (
-        t_shape,
+        input_dataset.data.shape[0],
         len(channel_names),
         output_z_shape,
     ) + input_dataset.data.shape[3:]
 
     # Create output dataset
     output_dataset = open_ome_zarr(
-        output_path, layout="fov", mode="w", channel_names=channel_names
+        output_path, layout="fov", mode="a", channel_names=channel_names
     )
-    output_array = output_dataset.create_zeros(
-        name="0",
-        shape=output_shape,
-        dtype=np.float32,
-        chunks=(
-            1,
-            1,
-            1,
+    if 0 in time_indices:
+        output_array = output_dataset.create_zeros(
+            name="0",
+            shape=output_shape,
+            dtype=np.float32,
+            chunks=(
+                1,
+                1,
+                1,
+            )
+            + input_dataset.data.shape[3:],  # chunk by YX
         )
-        + input_dataset.data.shape[3:],  # chunk by YX
-    )
+    else:
+        output_array = output_dataset[0]
 
     # Load data
     tczyx_uint16_numpy = input_dataset.data.oindex[:, channel_indices]

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -64,14 +64,14 @@ def apply_inverse_transfer_function_cli(
         time_indices = [settings.time_indices]
         t_shape = 1
     else:
-        ValueError(
+        raise ValueError(
             f"time_indices = {time_indices} should be `all`, a list of integers, or an integer."
         )
 
     # Check for invalid times
-    if np.max(time_indices) > input_dataset.data.shape[0]:
-        ValueError(
-            f"time_indices = {time_indices} includes a time index beyond the size the of the dataset = {input_dataset.data.shape[0]}"
+    if np.max(time_indices) > (input_dataset.data.shape[0] - 1):
+        raise ValueError(
+            f"time_indices = {time_indices} includes a time index beyond the maximum index of the dataset = {input_dataset.data.shape[0] - 1}"
         )
 
 

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -68,6 +68,13 @@ def apply_inverse_transfer_function_cli(
             f"time_indices = {time_indices} should be `all`, a list of integers, or an integer."
         )
 
+    # Check for invalid times
+    if np.max(time_indices) > input_dataset.data.shape[0]:
+        ValueError(
+            f"time_indices = {time_indices} includes a time index beyond the size the of the dataset = {input_dataset.data.shape[0]}"
+        )
+
+
     # Simplify important settings names
     recon_biref = settings.birefringence is not None
     recon_phase = settings.phase is not None

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -2,20 +2,21 @@ import click
 import numpy as np
 import torch
 from iohub import open_ome_zarr
-from recOrder.cli.printing import echo_headline, echo_settings
-from recOrder.cli.settings import ReconstructionSettings
-from recOrder.cli.parsing import (
-    input_data_path_argument,
-    config_path_option,
-    output_dataset_option,
-)
-from recOrder.io import utils
 from waveorder.models import (
     inplane_oriented_thick_pol3d,
+    isotropic_fluorescent_thick_3d,
     isotropic_thin_3d,
     phase_thick_3d,
-    isotropic_fluorescent_thick_3d,
 )
+
+from recOrder.cli.parsing import (
+    config_path_option,
+    input_data_path_argument,
+    output_dataset_option,
+)
+from recOrder.cli.printing import echo_headline, echo_settings
+from recOrder.cli.settings import ReconstructionSettings
+from recOrder.io import utils
 
 
 def _check_background_consistency(background_shape, data_shape):
@@ -73,7 +74,6 @@ def apply_inverse_transfer_function_cli(
         raise ValueError(
             f"time_indices = {time_indices} includes a time index beyond the maximum index of the dataset = {input_dataset.data.shape[0] - 1}"
         )
-
 
     # Simplify important settings names
     recon_biref = settings.birefringence is not None

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -111,7 +111,7 @@ def apply_inverse_transfer_function_cli(
     )
 
     # Create an empty TCZYX array if it doesn't exist
-    if not output_dataset.array_keys():
+    if "0" not in output_dataset:
         output_array = output_dataset.create_zeros(
             name="0",
             shape=output_shape,

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -57,17 +57,10 @@ def apply_inverse_transfer_function_cli(
     # Find time indices
     if settings.time_indices == "all":
         time_indices = range(input_dataset.data.shape[0])
-        t_shape = input_dataset.data.shape[0]
     elif isinstance(settings.time_indices, list):
         time_indices = settings.time_indices
-        t_shape = len(time_indices)
     elif isinstance(settings.time_indices, int):
         time_indices = [settings.time_indices]
-        t_shape = 1
-    else:
-        raise ValueError(
-            f"time_indices = {time_indices} should be `all`, a list of integers, or an integer."
-        )
 
     # Check for invalid times
     time_ubound = input_dataset.data.shape[0] - 1

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -162,7 +162,7 @@ def apply_inverse_transfer_function_cli(
             transfer_function_dataset["intensity_to_stokes_matrix"][0, 0, 0]
         )
 
-        for time_index in time_indices:
+        for output_index, time_index in enumerate(time_indices):
             # Apply
             reconstructed_parameters = (
                 inplane_oriented_thick_pol3d.apply_inverse_transfer_function(
@@ -175,7 +175,7 @@ def apply_inverse_transfer_function_cli(
             )
             # Save
             for param_index, parameter in enumerate(reconstructed_parameters):
-                output_array[time_index, param_index] = parameter
+                output_array[output_index, param_index] = parameter
 
     # [phase only]
     if recon_phase and (not recon_biref):
@@ -199,7 +199,7 @@ def apply_inverse_transfer_function_cli(
                 transfer_function_dataset["phase_transfer_function"][0, 0]
             )
 
-            for time_index in time_indices:
+            for output_index, time_index in enumerate(time_indices):
                 # Apply
                 (
                     _,
@@ -212,7 +212,7 @@ def apply_inverse_transfer_function_cli(
                 )
 
                 # Save
-                output_array[time_index, -1, 0] = yx_phase
+                output_array[output_index, -1, 0] = yx_phase
 
         # [phase only, 3]
         elif recon_dim == 3:
@@ -229,7 +229,7 @@ def apply_inverse_transfer_function_cli(
             )
 
             # Apply
-            for time_index in time_indices:
+            for output_index, time_index in enumerate(time_indices):
                 zyx_phase = phase_thick_3d.apply_inverse_transfer_function(
                     tczyx_data[time_index, 0],
                     real_potential_transfer_function,
@@ -240,7 +240,7 @@ def apply_inverse_transfer_function_cli(
                     **settings.phase.apply_inverse.dict(),
                 )
                 # Save
-                output_array[time_index, -1] = zyx_phase
+                output_array[output_index, -1] = zyx_phase
 
     # [biref and phase]
     if recon_biref and recon_phase:
@@ -265,7 +265,7 @@ def apply_inverse_transfer_function_cli(
                 transfer_function_dataset["phase_transfer_function"][0, 0]
             )
 
-            for time_index in time_indices:
+            for output_index, time_index in enumerate(time_indices):
                 # Apply
                 reconstructed_parameters_2d = inplane_oriented_thick_pol3d.apply_inverse_transfer_function(
                     tczyx_data[time_index],
@@ -299,8 +299,8 @@ def apply_inverse_transfer_function_cli(
                 for param_index, parameter in enumerate(
                     reconstructed_parameters_2d
                 ):
-                    output_array[time_index, param_index] = parameter
-                output_array[time_index, -1, 0] = yx_phase
+                    output_array[output_index, param_index] = parameter
+                output_array[output_index, -1, 0] = yx_phase
 
         # [biref and phase, 3]
         elif recon_dim == 3:
@@ -323,7 +323,7 @@ def apply_inverse_transfer_function_cli(
             )
 
             # Apply
-            for time_index in time_indices:
+            for output_index, time_index in enumerate(time_indices):
                 reconstructed_parameters_3d = inplane_oriented_thick_pol3d.apply_inverse_transfer_function(
                     tczyx_data[time_index],
                     intensity_to_stokes_matrix,
@@ -347,8 +347,8 @@ def apply_inverse_transfer_function_cli(
                 for param_index, parameter in enumerate(
                     reconstructed_parameters_3d
                 ):
-                    output_array[time_index, param_index] = parameter
-                output_array[time_index, -1] = zyx_phase
+                    output_array[output_index, param_index] = parameter
+                output_array[output_index, -1] = zyx_phase
 
     # [fluo]
     if recon_fluo:
@@ -367,7 +367,7 @@ def apply_inverse_transfer_function_cli(
             )
 
             # Apply
-            for time_index in time_indices:
+            for output_index, time_index in enumerate(time_indices):
                 zyx_recon = isotropic_fluorescent_thick_3d.apply_inverse_transfer_function(
                     tczyx_data[time_index, 0],
                     optical_transfer_function,
@@ -376,7 +376,7 @@ def apply_inverse_transfer_function_cli(
                 )
 
                 # Save
-                output_array[time_index, 0] = zyx_recon
+                output_array[output_index, 0] = zyx_recon
 
     output_dataset.zattrs["settings"] = settings.dict()
 

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -70,9 +70,10 @@ def apply_inverse_transfer_function_cli(
         )
 
     # Check for invalid times
-    if np.max(time_indices) > (input_dataset.data.shape[0] - 1):
+    time_ubound = input_dataset.data.shape[0] - 1
+    if np.max(time_indices) > time_ubound:
         raise ValueError(
-            f"time_indices = {time_indices} includes a time index beyond the maximum index of the dataset = {input_dataset.data.shape[0] - 1}"
+            f"time_indices = {time_indices} includes a time index beyond the maximum index of the dataset = {time_ubound}"
         )
 
     # Simplify important settings names

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -53,8 +53,20 @@ def apply_inverse_transfer_function_cli(
             input_dataset.channel_names.index(input_channel_name)
         )
 
-    # Load dataset shape
-    t_shape = input_dataset.data.shape[0]
+    # Find time indices
+    if settings.time_indices == "all":
+        time_indices = range(input_dataset.data.shape[0])
+        t_shape = input_dataset.data.shape[0]
+    elif isinstance(settings.time_indices, list):
+        time_indices = settings.time_indices
+        t_shape = len(time_indices)
+    elif isinstance(settings.time_indices, int):
+        time_indices = [settings.time_indices]
+        t_shape = 1
+    else:
+        ValueError(
+            f"time_indices = {time_indices} should be `all`, a list of integers, or an integer."
+        )
 
     # Simplify important settings names
     recon_biref = settings.birefringence is not None
@@ -143,7 +155,7 @@ def apply_inverse_transfer_function_cli(
             transfer_function_dataset["intensity_to_stokes_matrix"][0, 0, 0]
         )
 
-        for time_index in range(t_shape):
+        for time_index in time_indices:
             # Apply
             reconstructed_parameters = (
                 inplane_oriented_thick_pol3d.apply_inverse_transfer_function(
@@ -180,7 +192,7 @@ def apply_inverse_transfer_function_cli(
                 transfer_function_dataset["phase_transfer_function"][0, 0]
             )
 
-            for time_index in range(t_shape):
+            for time_index in time_indices:
                 # Apply
                 (
                     _,
@@ -210,7 +222,7 @@ def apply_inverse_transfer_function_cli(
             )
 
             # Apply
-            for time_index in range(t_shape):
+            for time_index in time_indices:
                 zyx_phase = phase_thick_3d.apply_inverse_transfer_function(
                     tczyx_data[time_index, 0],
                     real_potential_transfer_function,
@@ -246,7 +258,7 @@ def apply_inverse_transfer_function_cli(
                 transfer_function_dataset["phase_transfer_function"][0, 0]
             )
 
-            for time_index in range(t_shape):
+            for time_index in time_indices:
                 # Apply
                 reconstructed_parameters_2d = inplane_oriented_thick_pol3d.apply_inverse_transfer_function(
                     tczyx_data[time_index],
@@ -304,7 +316,7 @@ def apply_inverse_transfer_function_cli(
             )
 
             # Apply
-            for time_index in range(t_shape):
+            for time_index in time_indices:
                 reconstructed_parameters_3d = inplane_oriented_thick_pol3d.apply_inverse_transfer_function(
                     tczyx_data[time_index],
                     intensity_to_stokes_matrix,
@@ -348,7 +360,7 @@ def apply_inverse_transfer_function_cli(
             )
 
             # Apply
-            for time_index in range(t_shape):
+            for time_index in time_indices:
                 zyx_recon = isotropic_fluorescent_thick_3d.apply_inverse_transfer_function(
                     tczyx_data[time_index, 0],
                     optical_transfer_function,

--- a/recOrder/cli/settings.py
+++ b/recOrder/cli/settings.py
@@ -9,7 +9,7 @@ from pydantic import (
     root_validator,
     validator,
 )
-from typing import Literal, List, Optional
+from typing import Literal, List, Optional, Union
 
 # This file defines the configuration settings for the CLI.
 
@@ -148,6 +148,9 @@ class FluorescenceSettings(MyBaseModel):
 # Top level settings
 class ReconstructionSettings(MyBaseModel):
     input_channel_names: List[str] = [f"State{i}" for i in range(4)]
+    time_indices: Union[
+        NonNegativeInt, List[NonNegativeInt], Literal["all"]
+    ] = "all"
     reconstruction_dimension: Literal[2, 3] = 3
     birefringence: Optional[BirefringenceSettings]
     phase: Optional[PhaseSettings]

--- a/recOrder/tests/cli_tests/test_reconstruct.py
+++ b/recOrder/tests/cli_tests/test_reconstruct.py
@@ -1,9 +1,10 @@
 import numpy as np
-from recOrder.cli.main import cli
-from recOrder.cli import settings
-from recOrder.io import utils
 from click.testing import CliRunner
 from iohub.ngff import open_ome_zarr
+
+from recOrder.cli import settings
+from recOrder.cli.main import cli
+from recOrder.io import utils
 
 
 def test_reconstruct(tmp_path):
@@ -23,11 +24,13 @@ def test_reconstruct(tmp_path):
     birefringence_settings = settings.BirefringenceSettings(
         transfer_function=settings.BirefringenceTransferFunctionSettings()
     )
+
+    # birefringence_option, time_indices, phase_option, dimension_option, time_length_target
     all_options = [
-        (birefringence_settings, [0], None, 2),
-        (birefringence_settings, 0, settings.PhaseSettings(), 2),
-        (birefringence_settings, [0, 1], None, 3),
-        (birefringence_settings, "all", settings.PhaseSettings(), 3),
+        (birefringence_settings, [0], None, 2, 1),
+        (birefringence_settings, 0, settings.PhaseSettings(), 2, 1),
+        (birefringence_settings, [0, 1], None, 3, 2),
+        (birefringence_settings, "all", settings.PhaseSettings(), 3, 2),
     ]
 
     for (
@@ -35,6 +38,7 @@ def test_reconstruct(tmp_path):
         time_indices,
         phase_option,
         dimension_option,
+        time_length_target,
     ) in all_options:
         if (birefringence_option is None) and (phase_option is None):
             continue
@@ -89,7 +93,7 @@ def test_reconstruct(tmp_path):
 
         # Check output
         result_dataset = open_ome_zarr(result_path)
-        assert result_dataset["0"].shape[0] in {1, 2}
+        assert result_dataset["0"].shape[0] == time_length_target
         assert result_dataset["0"].shape[3:] == (5, 6)
 
         # Test direct recon
@@ -106,4 +110,5 @@ def test_reconstruct(tmp_path):
         )
         assert result_path.exists()
         assert result_inv.exit_code == 0
+        assert "Reconstructing" in result_inv.output
         assert "Reconstructing" in result_inv.output

--- a/recOrder/tests/cli_tests/test_reconstruct.py
+++ b/recOrder/tests/cli_tests/test_reconstruct.py
@@ -27,19 +27,19 @@ def test_reconstruct(tmp_path):
 
     # birefringence_option, time_indices, phase_option, dimension_option, time_length_target
     all_options = [
-        (birefringence_settings, [0, 3, 4], None, 2, 3),
-        (birefringence_settings, 0, settings.PhaseSettings(), 2, 1),
-        (birefringence_settings, [0, 1], None, 3, 2),
+        (birefringence_settings, [0, 3, 4], None, 2, 5),
+        (birefringence_settings, 0, settings.PhaseSettings(), 2, 5),
+        (birefringence_settings, [0, 1], None, 3, 5),
         (birefringence_settings, "all", settings.PhaseSettings(), 3, 5),
     ]
 
-    for (
+    for i, (
         birefringence_option,
         time_indices,
         phase_option,
         dimension_option,
         time_length_target,
-    ) in all_options:
+    ) in enumerate(all_options):
         if (birefringence_option is None) and (phase_option is None):
             continue
 
@@ -72,7 +72,7 @@ def test_reconstruct(tmp_path):
         assert tf_path.exists()
 
         # Apply the tf
-        result_path = input_path.with_name("result.zarr")
+        result_path = input_path.with_name(f"result{i}.zarr")
 
         result_inv = runner.invoke(
             cli,

--- a/recOrder/tests/cli_tests/test_reconstruct.py
+++ b/recOrder/tests/cli_tests/test_reconstruct.py
@@ -18,7 +18,7 @@ def test_reconstruct(tmp_path):
         mode="w",
         channel_names=channel_names,
     )
-    dataset.create_zeros("0", (2, 4, 4, 5, 6), dtype=np.uint16)
+    dataset.create_zeros("0", (5, 4, 4, 5, 6), dtype=np.uint16)
 
     # Setup options
     birefringence_settings = settings.BirefringenceSettings(
@@ -27,10 +27,10 @@ def test_reconstruct(tmp_path):
 
     # birefringence_option, time_indices, phase_option, dimension_option, time_length_target
     all_options = [
-        (birefringence_settings, [0], None, 2, 1),
+        (birefringence_settings, [0, 3, 4], None, 2, 3),
         (birefringence_settings, 0, settings.PhaseSettings(), 2, 1),
         (birefringence_settings, [0, 1], None, 3, 2),
-        (birefringence_settings, "all", settings.PhaseSettings(), 3, 2),
+        (birefringence_settings, "all", settings.PhaseSettings(), 3, 5),
     ]
 
     for (


### PR DESCRIPTION
`recorder reconstruct` naively loops through all time points, applying the reconstruction as it goes. This default is limiting for datasets with a large number of time points where it is more convenient to reconstruct a single time point on a single core (via multiprocessing or slurm). 

This PR adds a configuration-file option `time_indices` with signature:
`time_indices: Union[NonNegativeInt, List[NonNegativeInt], Literal["all"]] = "all"`

By default `time_indices: "all"` reconstructs all time point, which is backwards compatible. 
If `time_indices: 5`, then only time-point 5 will be reconstructed.
Finally, if
```
time_indices:
- 0 
- 5
- 10
```
then the 0th, 5th, and 10th indices will be reconstructed. 

@edyoshikun requested this feature for simplifying parallel reconstructions with `recOrder`, and I expect we'll use a similar feature in `mantis`. 