### PR TITLE
Standardize CLI

### DIFF
--- a/docs/reconstruction-guide.md
+++ b/docs/reconstruction-guide.md
@@ -10,12 +10,23 @@ The main command `reconstruct` command is composed of two subcommands: `compute-
 
 A reconstruction can be performed with a single `reconstruct` call. For example:
 ```
-recorder reconstruct data.zarr/0/0/0 -c config.yml -o reconstruction.zarr
+recorder reconstruct `
+    -i ./data.zarr/*/*/* `
+    -c ./config.yml `
+    -o ./reconstruction.zarr
 ```
 Equivalently, a reconstruction can be performed with a `compute-tf` call followed by an `apply-inv-tf` call. For example:
 ```
-recorder compute-tf data.zarr/0/0/0 -c config.yml -o tf.zarr
-recorder apply-inv-tf data.zarr/0/0/0 tf.zarr -c config.yml -o reconstruction.zarr
+recorder compute-tf `
+    -i ./data.zarr/0/0/0 `
+    -c ./config.yml `
+    -o ./tf.zarr
+
+recorder apply-inv-tf 
+    -i ./data.zarr/*/*/* `
+    -t ./tf.zarr `
+    -c ./config.yml `
+    -o ./reconstruction.zarr
 ```
 Computing the transfer function is typically the most expensive part of the reconstruction, so saving a transfer function then applying it to many datasets can save time. 
 

--- a/docs/reconstruction-guide.md
+++ b/docs/reconstruction-guide.md
@@ -30,6 +30,12 @@ recorder apply-inv-tf
 ```
 Computing the transfer function is typically the most expensive part of the reconstruction, so saving a transfer function then applying it to many datasets can save time. 
 
+## Input options
+
+The input `-i` flag always accepts a list of inputs, either explicitly e.g. `-i ./data.zarr/A/1/0 ./data.zarr/A/2/0` or through wildcards `-i ./data.zarr/*/*/*`. The positions in a high-content screening `.zarr` store are organized into `/row/col/fov` folders, so `./input.zarr/*/*/*` creates a list of all positions in a dataset. 
+
+The `recorder compute-tf` command accepts a list of inputs, but it only computes the transfer function for the first position in the list. The `apply-inv-tf` command accepts a list of inputs and applies the same transfer function to all of the inputs, which requires that all positions contain arrays with matching TCZYX shapes.
+
 ## What types of reconstructions are supported?
 See `/recOrder/examples/` for a list of example configuration files. 
 

--- a/recOrder/acq/acquisition_workers.py
+++ b/recOrder/acq/acquisition_workers.py
@@ -1,35 +1,36 @@
 from __future__ import annotations
 
-from qtpy.QtCore import Signal
-from iohub import open_ome_zarr
-from iohub.convert import TIFFConverter
-from recOrder.cli import settings
-from recOrder.cli.compute_transfer_function import (
-    compute_transfer_function_cli,
-)
-from recOrder.cli.apply_inverse_transfer_function import (
-    apply_inverse_transfer_function_cli,
-)
-from recOrder.acq.acq_functions import (
-    generate_acq_settings,
-    acquire_from_settings,
-)
-from recOrder.io.utils import model_to_yaml
-from recOrder.io.utils import ram_message
-from napari.qt.threading import WorkerBaseSignals, WorkerBase
-from napari.utils.notifications import show_warning
 import logging
-import numpy as np
 import os
 import shutil
 
 # type hint/check
 from typing import TYPE_CHECKING
 
+import numpy as np
+from iohub import open_ome_zarr
+from iohub.convert import TIFFConverter
+from napari.qt.threading import WorkerBase, WorkerBaseSignals
+from napari.utils.notifications import show_warning
+from qtpy.QtCore import Signal
+
+from recOrder.acq.acq_functions import (
+    acquire_from_settings,
+    generate_acq_settings,
+)
+from recOrder.cli import settings
+from recOrder.cli.apply_inverse_transfer_function import (
+    apply_inverse_transfer_function_cli,
+)
+from recOrder.cli.compute_transfer_function import (
+    compute_transfer_function_cli,
+)
+from recOrder.io.utils import model_to_yaml, ram_message
+
 # avoid runtime import error
 if TYPE_CHECKING:
-    from recOrder.plugin.main_widget import MainWidget
     from recOrder.calib.Calibration import QLIPP_Calibration
+    from recOrder.plugin.main_widget import MainWidget
 
 
 def _generate_reconstruction_config_from_gui(
@@ -298,16 +299,16 @@ class BFAcquisitionWorker(WorkerBase):
 
         # TODO: skip if config files match
         compute_transfer_function_cli(
-            input_data_path,
-            self.config_path,
-            transfer_function_path,
+            input_position_dirpath=input_data_path,
+            config_filepath=self.config_path,
+            output_dirpath=transfer_function_path,
         )
 
         apply_inverse_transfer_function_cli(
-            input_data_path,
-            transfer_function_path,
-            self.config_path,
-            reconstruction_path,
+            input_position_dirpath=input_data_path,
+            transfer_function_dirpath=transfer_function_path,
+            config_filepath=self.config_path,
+            output_position_dirpath=reconstruction_path,
         )
 
         # Read reconstruction to pass to emitters
@@ -630,16 +631,16 @@ class PolarizationAcquisitionWorker(WorkerBase):
 
         # TODO: skip if config files match
         compute_transfer_function_cli(
-            input_data_path,
-            self.config_path,
-            transfer_function_path,
+            input_position_dirpath=input_data_path,
+            config_filepath=self.config_path,
+            output_dirpath=transfer_function_path,
         )
 
         apply_inverse_transfer_function_cli(
-            input_data_path,
-            transfer_function_path,
-            self.config_path,
-            reconstruction_path,
+            input_position_dirpath=input_data_path,
+            transfer_function_dirpath=transfer_function_path,
+            config_filepath=self.config_path,
+            output_position_dirpath=reconstruction_path,
         )
 
         # Read reconstruction to pass to emitters
@@ -699,4 +700,5 @@ class PolarizationAcquisitionWorker(WorkerBase):
                     dp.close()
                 break
             else:
+                continue
                 continue

--- a/recOrder/acq/acquisition_workers.py
+++ b/recOrder/acq/acquisition_workers.py
@@ -701,4 +701,3 @@ class PolarizationAcquisitionWorker(WorkerBase):
                 break
             else:
                 continue
-                continue

--- a/recOrder/calib/calibration_workers.py
+++ b/recOrder/calib/calibration_workers.py
@@ -484,6 +484,3 @@ def load_calibration(calib, metadata: MetadataReader):
     )
 
     return calib
-    )
-
-    return calib

--- a/recOrder/calib/calibration_workers.py
+++ b/recOrder/calib/calibration_workers.py
@@ -1,34 +1,37 @@
 from __future__ import annotations
 
-from qtpy.QtCore import Signal
-from iohub import open_ome_zarr
-from napari.qt.threading import WorkerBaseSignals, WorkerBase, thread_worker
-from recOrder.cli import settings
-from recOrder.io.core_functions import set_lc_state, snap_and_average
-from recOrder.io.utils import MockEmitter, model_to_yaml
-from recOrder.calib.Calibration import LC_DEVICE_NAME
-from recOrder.io.metadata_reader import MetadataReader, get_last_metadata_file
-from recOrder.cli.compute_transfer_function import (
-    compute_transfer_function_cli,
-)
-from recOrder.cli.apply_inverse_transfer_function import (
-    apply_inverse_transfer_function_cli,
-)
+import glob
+import json
+import logging
 import os
 import shutil
-import numpy as np
-import glob
-import logging
-import json
 
 # type hint/check
 from typing import TYPE_CHECKING
 
+import numpy as np
+from iohub import open_ome_zarr
+from napari.qt.threading import WorkerBase, WorkerBaseSignals, thread_worker
+from qtpy.QtCore import Signal
+
+from recOrder.calib.Calibration import LC_DEVICE_NAME
+from recOrder.cli import settings
+from recOrder.cli.apply_inverse_transfer_function import (
+    apply_inverse_transfer_function_cli,
+)
+from recOrder.cli.compute_transfer_function import (
+    compute_transfer_function_cli,
+)
+from recOrder.io.core_functions import set_lc_state, snap_and_average
+from recOrder.io.metadata_reader import MetadataReader, get_last_metadata_file
+from recOrder.io.utils import MockEmitter, model_to_yaml
+
 # avoid runtime import error
 if TYPE_CHECKING:
     from _typeshed import StrOrBytesPath
-    from recOrder.plugin.main_widget import MainWidget
+
     from recOrder.calib.Calibration import QLIPP_Calibration
+    from recOrder.plugin.main_widget import MainWidget
 
 
 class CalibrationSignals(WorkerBaseSignals):
@@ -369,16 +372,16 @@ class BackgroundCaptureWorker(
         reconstruction_path = os.path.join(bg_path, "reconstruction.zarr")
 
         compute_transfer_function_cli(
-            input_data_path,
-            reconstruction_config_path,
-            transfer_function_path,
+            input_position_dirpath=input_data_path,
+            config_filepath=reconstruction_config_path,
+            output_dirpath=transfer_function_path,
         )
 
         apply_inverse_transfer_function_cli(
-            input_data_path,
-            transfer_function_path,
-            reconstruction_config_path,
-            reconstruction_path,
+            input_position_dirpath=input_data_path,
+            transfer_function_dirpath=transfer_function_path,
+            config_filepath=reconstruction_config_path,
+            output_position_dirpath=reconstruction_path,
         )
 
         # Load reconstructions from file for layers
@@ -478,6 +481,9 @@ def load_calibration(calib, metadata: MetadataReader):
         calib.calculate_extinction(
             calib.swing, calib.I_Black, calib.I_Ext, calib.I_Elliptical
         )
+    )
+
+    return calib
     )
 
     return calib

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -394,7 +394,6 @@ def apply_inverse_transfer_function_cli(
 
 
 @click.command()
-@click.help_option("-h", "--help")
 @input_data_path_argument()
 @click.argument(
     "transfer_function_path",

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import click
 import numpy as np
 import torch
@@ -31,11 +33,11 @@ def _check_background_consistency(background_shape, data_shape):
 
 
 def apply_inverse_transfer_function_cli(
-    input_position_dirpath,
-    transfer_function_dirpath,
-    config_filepath,
-    output_position_dirpath,
-):
+    input_position_dirpath: Path,
+    transfer_function_dirpath: Path,
+    config_filepath: Path,
+    output_position_dirpath: Path,
+) -> None:
     echo_headline("Starting reconstruction...")
 
     # Load datasets
@@ -407,11 +409,11 @@ def apply_inverse_transfer_function_cli(
 @config_filepath()
 @output_dirpath()
 def apply_inv_tf(
-    input_position_dirpaths: list[str],
-    transfer_function_dirpath: str,
-    config_filepath: str,
-    output_dirpath: str,
-):
+    input_position_dirpaths: list[Path],
+    transfer_function_dirpath: Path,
+    config_filepath: Path,
+    output_dirpath: Path,
+) -> None:
     """
     Apply an inverse transfer function to a dataset using a configuration file.
 

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import click
 import numpy as np
 import torch
@@ -11,12 +13,14 @@ from waveorder.models import (
 )
 
 from recOrder.cli.parsing import (
-    config_path_option,
-    input_data_path_argument,
-    output_dataset_option,
+    config_filepath,
+    input_position_dirpaths,
+    output_dirpath,
+    transfer_function_dirpath,
 )
 from recOrder.cli.printing import echo_headline, echo_settings
 from recOrder.cli.settings import ReconstructionSettings
+from recOrder.cli.utils import get_output_paths
 from recOrder.io import utils
 
 
@@ -29,23 +33,26 @@ def _check_background_consistency(background_shape, data_shape):
 
 
 def apply_inverse_transfer_function_cli(
-    input_data_path, transfer_function_path, config_path, output_path
+    input_position_dirpath,
+    transfer_function_dirpath,
+    config_filepath,
+    output_position_dirpath,
 ):
     echo_headline("Starting reconstruction...")
 
     # Load datasets
-    transfer_function_dataset = open_ome_zarr(transfer_function_path)
-    input_dataset = open_ome_zarr(input_data_path)
+    transfer_function_dataset = open_ome_zarr(transfer_function_dirpath)
+    input_dataset = open_ome_zarr(input_position_dirpath)
 
     # Load config file
-    settings = utils.yaml_to_model(config_path, ReconstructionSettings)
+    settings = utils.yaml_to_model(config_filepath, ReconstructionSettings)
 
     # Check input channel names
     if not set(settings.input_channel_names).issubset(
         input_dataset.channel_names
     ):
         raise ValueError(
-            f"Each of the input_channel_names = {settings.input_channel_names} in {config_path} must appear in the dataset {input_data_path} which currently contains channel_names = {input_dataset.channel_names}."
+            f"Each of the input_channel_names = {settings.input_channel_names} in {config_filepath} must appear in the dataset {input_position_dirpath} which currently contains channel_names = {input_dataset.channel_names}."
         )
 
     # Find channel indices
@@ -108,7 +115,10 @@ def apply_inverse_transfer_function_cli(
 
     # Create output dataset
     output_dataset = open_ome_zarr(
-        output_path, layout="fov", mode="a", channel_names=channel_names
+        output_position_dirpath,
+        layout="fov",
+        mode="w",
+        channel_names=channel_names,
     )
 
     # Create an empty TCZYX array if it doesn't exist
@@ -383,35 +393,45 @@ def apply_inverse_transfer_function_cli(
 
     output_dataset.zattrs["settings"] = settings.dict()
 
-    echo_headline(f"Closing {output_path}\n")
+    echo_headline(f"Closing {output_position_dirpath}\n")
     output_dataset.close()
     transfer_function_dataset.close()
     input_dataset.close()
 
     echo_headline(
-        f"Recreate this reconstruction with:\n$ recorder apply-inv-tf {input_data_path} {transfer_function_path} -c {config_path} -o {output_path}"
+        f"Recreate this reconstruction with:\n$ recorder apply-inv-tf {input_position_dirpath} {transfer_function_dirpath} -c {config_filepath} -o {output_position_dirpath}"
     )
 
 
 @click.command()
-@input_data_path_argument()
-@click.argument(
-    "transfer_function_path",
-    type=click.Path(exists=True),
-)
-@config_path_option()
-@output_dataset_option(default="./reconstruction.zarr")
+@input_position_dirpaths()
+@transfer_function_dirpath()
+@config_filepath()
+@output_dirpath()
 def apply_inv_tf(
-    input_data_path, transfer_function_path, config_path, output_path
+    input_position_dirpaths: List[str],
+    transfer_function_dirpath: str,
+    config_filepath: str,
+    output_dirpath: str,
 ):
     """
     Apply an inverse transfer function to a dataset using a configuration file.
 
     See /examples for example configuration files.
 
-    Example usage:\n
-    $ recorder apply-inv-tf input.zarr/0/0/0 transfer-function.zarr -c /examples/birefringence.yml -o output.zarr
+    >> recorder apply-inv-tf -i input.zarr/*/*/* -t transfer-function.zarr -c /examples/birefringence.yml -o output.zarr
     """
-    apply_inverse_transfer_function_cli(
-        input_data_path, transfer_function_path, config_path, output_path
+
+    output_position_dirpaths = get_output_paths(
+        input_position_dirpaths, output_dirpath
     )
+
+    for input_position_dirpath, output_position_dirpath in zip(
+        input_position_dirpaths, output_position_dirpaths
+    ):
+        apply_inverse_transfer_function_cli(
+            input_position_dirpath,
+            transfer_function_dirpath,
+            config_filepath,
+            output_position_dirpath,
+        )

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -115,7 +115,7 @@ def apply_inverse_transfer_function_cli(
     output_dataset = open_ome_zarr(
         output_position_dirpath,
         layout="fov",
-        mode="w",
+        mode="a",
         channel_names=channel_names,
     )
 

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -415,6 +415,9 @@ def apply_inv_tf(
     """
     Apply an inverse transfer function to a dataset using a configuration file.
 
+    Applies a transfer function to all positions in the list `input-position-dirpaths`,
+    so all positions must have the same TCZYX shape.
+
     See /examples for example configuration files.
 
     >> recorder apply-inv-tf -i ./input.zarr/*/*/* -t ./transfer-function.zarr -c /examples/birefringence.yml -o ./output.zarr

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -419,7 +419,7 @@ def apply_inv_tf(
 
     See /examples for example configuration files.
 
-    >> recorder apply-inv-tf -i input.zarr/*/*/* -t transfer-function.zarr -c /examples/birefringence.yml -o output.zarr
+    >> recorder apply-inv-tf -i ./input.zarr/*/*/* -t ./transfer-function.zarr -c /examples/birefringence.yml -o ./output.zarr
     """
 
     output_position_dirpaths = get_output_paths(

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import click
 import numpy as np
 import torch
@@ -409,7 +407,7 @@ def apply_inverse_transfer_function_cli(
 @config_filepath()
 @output_dirpath()
 def apply_inv_tf(
-    input_position_dirpaths: List[str],
+    input_position_dirpaths: list[str],
     transfer_function_dirpath: str,
     config_filepath: str,
     output_dirpath: str,

--- a/recOrder/cli/compute_transfer_function.py
+++ b/recOrder/cli/compute_transfer_function.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import click
 import numpy as np
 from iohub import open_ome_zarr
@@ -139,8 +141,8 @@ def generate_and_save_fluorescence_transfer_function(
 
 
 def compute_transfer_function_cli(
-    input_position_dirpath, config_filepath, output_dirpath
-):
+    input_position_dirpath: Path, config_filepath: Path, output_dirpath: Path
+) -> None:
     """CLI command to compute the transfer function given a configuration file path
     and a desired output path.
     """
@@ -203,10 +205,10 @@ def compute_transfer_function_cli(
 @config_filepath()
 @output_dirpath()
 def compute_tf(
-    input_position_dirpaths: list[str],
-    config_filepath: str,
-    output_dirpath: int,
-):
+    input_position_dirpaths: list[Path],
+    config_filepath: Path,
+    output_dirpath: Path,
+) -> None:
     """
     Compute a transfer function using a dataset and configuration file.
 

--- a/recOrder/cli/compute_transfer_function.py
+++ b/recOrder/cli/compute_transfer_function.py
@@ -1,20 +1,21 @@
 import click
 import numpy as np
 from iohub import open_ome_zarr
-from recOrder.cli.printing import echo_settings, echo_headline
-from recOrder.cli.settings import ReconstructionSettings
-from recOrder.cli.parsing import (
-    input_data_path_argument,
-    config_path_option,
-    output_dataset_option,
-)
-from recOrder.io import utils
 from waveorder.models import (
     inplane_oriented_thick_pol3d,
+    isotropic_fluorescent_thick_3d,
     isotropic_thin_3d,
     phase_thick_3d,
-    isotropic_fluorescent_thick_3d,
 )
+
+from recOrder.cli.parsing import (
+    config_path_option,
+    input_data_path_argument,
+    output_dataset_option,
+)
+from recOrder.cli.printing import echo_headline, echo_settings
+from recOrder.cli.settings import ReconstructionSettings
+from recOrder.io import utils
 
 
 def generate_and_save_birefringence_transfer_function(settings, dataset):
@@ -203,7 +204,6 @@ def compute_transfer_function_cli(input_data_path, config_path, output_path):
 
 
 @click.command()
-@click.help_option("-h", "--help")
 @input_data_path_argument()
 @config_path_option()
 @output_dataset_option(default="./transfer-function.zarr")
@@ -216,4 +216,5 @@ def compute_tf(input_data_path, config_path, output_path):
     Example usage:\n
     $ recorder compute-tf input.zarr/0/0/0 -c /examples/birefringence.yml -o transfer_function.zarr
     """
+    compute_transfer_function_cli(input_data_path, config_path, output_path)
     compute_transfer_function_cli(input_data_path, config_path, output_path)

--- a/recOrder/cli/compute_transfer_function.py
+++ b/recOrder/cli/compute_transfer_function.py
@@ -141,7 +141,7 @@ def generate_and_save_fluorescence_transfer_function(
 
 
 def compute_transfer_function_cli(
-    input_position_dirpaths, config_filepath, output_dirpath
+    input_position_dirpath, config_filepath, output_dirpath
 ):
     """CLI command to compute the transfer function given a configuration file path
     and a desired output path.
@@ -156,7 +156,7 @@ def compute_transfer_function_cli(
 
     # Read shape from input dataset
     input_dataset = open_ome_zarr(
-        input_position_dirpaths[0], layout="fov", mode="r"
+        input_position_dirpath, layout="fov", mode="r"
     )
     zyx_shape = input_dataset.data.shape[
         2:
@@ -217,5 +217,5 @@ def compute_tf(
     >> recorder compute-tf -i ./input.zarr/0/0/0 -c ./examples/birefringence.yml -o ./transfer_function.zarr
     """
     compute_transfer_function_cli(
-        input_position_dirpaths, config_filepath, output_dirpath
+        input_position_dirpaths[0], config_filepath, output_dirpath
     )

--- a/recOrder/cli/compute_transfer_function.py
+++ b/recOrder/cli/compute_transfer_function.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import click
 import numpy as np
 from iohub import open_ome_zarr
@@ -205,7 +203,7 @@ def compute_transfer_function_cli(
 @config_filepath()
 @output_dirpath()
 def compute_tf(
-    input_position_dirpaths: List[str],
+    input_position_dirpaths: list[str],
     config_filepath: str,
     output_dirpath: int,
 ):

--- a/recOrder/cli/compute_transfer_function.py
+++ b/recOrder/cli/compute_transfer_function.py
@@ -210,7 +210,10 @@ def compute_tf(
     """
     Compute a transfer function using a dataset and configuration file.
 
-    See /examples/ for example configuration files.
+    Calculates the transfer function based on the shape of the first position
+    in the list `input-position-dirpaths`.
+
+    See /examples for example configuration files.
 
     >> recorder compute-tf -i ./input.zarr/0/0/0 -c ./examples/birefringence.yml -o ./transfer_function.zarr
     """

--- a/recOrder/cli/main.py
+++ b/recOrder/cli/main.py
@@ -18,6 +18,6 @@ def cli():
     """\033[92mrecOrder: Computational Toolkit for Label-Free Imaging\033[0m\n"""
 
 
+cli.add_command(reconstruct)
 cli.add_command(compute_tf)
 cli.add_command(apply_inv_tf)
-cli.add_command(reconstruct)

--- a/recOrder/cli/main.py
+++ b/recOrder/cli/main.py
@@ -4,12 +4,20 @@ from recOrder.cli.apply_inverse_transfer_function import apply_inv_tf
 from recOrder.cli.compute_transfer_function import compute_tf
 from recOrder.cli.reconstruct import reconstruct
 
+CONTEXT = {"help_option_names": ["-h", "--help"]}
 
-@click.group()
+
+# `recorder -h` will show subcommands in the order they are added
+class NaturalOrderGroup(click.Group):
+    def list_commands(self, ctx):
+        return self.commands.keys()
+
+
+@click.group(context_settings=CONTEXT, cls=NaturalOrderGroup)
 def cli():
     """\033[92mrecOrder: Computational Toolkit for Label-Free Imaging\033[0m\n"""
 
 
-cli.add_command(reconstruct)
 cli.add_command(compute_tf)
 cli.add_command(apply_inv_tf)
+cli.add_command(reconstruct)

--- a/recOrder/cli/option_eat_all.py
+++ b/recOrder/cli/option_eat_all.py
@@ -1,0 +1,45 @@
+import click
+
+
+# Copied directly from https://stackoverflow.com/a/48394004
+# Enables `-i ./input.zarr/*/*/*`
+class OptionEatAll(click.Option):
+    def __init__(self, *args, **kwargs):
+        self.save_other_options = kwargs.pop('save_other_options', True)
+        nargs = kwargs.pop('nargs', -1)
+        assert nargs == -1, 'nargs, if set, must be -1 not {}'.format(nargs)
+        super(OptionEatAll, self).__init__(*args, **kwargs)
+        self._previous_parser_process = None
+        self._eat_all_parser = None
+
+    def add_to_parser(self, parser, ctx):
+        def parser_process(value, state):
+            # method to hook to the parser.process
+            done = False
+            value = [value]
+            if self.save_other_options:
+                # grab everything up to the next option
+                while state.rargs and not done:
+                    for prefix in self._eat_all_parser.prefixes:
+                        if state.rargs[0].startswith(prefix):
+                            done = True
+                    if not done:
+                        value.append(state.rargs.pop(0))
+            else:
+                # grab everything remaining
+                value += state.rargs
+                state.rargs[:] = []
+            value = tuple(value)
+
+            # call the actual process
+            self._previous_parser_process(value, state)
+
+        retval = super(OptionEatAll, self).add_to_parser(parser, ctx)
+        for name in self.opts:
+            our_parser = parser._long_opt.get(name) or parser._short_opt.get(name)
+            if our_parser:
+                self._eat_all_parser = our_parser
+                self._previous_parser_process = our_parser.process
+                our_parser.process = parser_process
+                break
+        return retval

--- a/recOrder/cli/parsing.py
+++ b/recOrder/cli/parsing.py
@@ -17,7 +17,7 @@ def _validate_and_process_paths(
         with open_ome_zarr(path, mode="r") as dataset:
             if isinstance(dataset, Plate):
                 raise ValueError(
-                    "Please supply a single position instead of an HCS plate. Likely fix: replace 'input.zarr' with 'input.zarr/0/0/0'"
+                    "Please supply a list of positions instead of an HCS plate. Likely fix: replace 'input.zarr' with 'input.zarr/*/*/*' or 'input.zarr/0/0/0'"
                 )
     return input_paths
 
@@ -29,8 +29,9 @@ def input_position_dirpaths() -> Callable:
             "-i",
             cls=OptionEatAll,
             type=tuple,
+            required=True,
             callback=_validate_and_process_paths,
-            help="Paths to input positions",
+            help="List of paths to input positions, each with the same TCZYX shape. Supports wildcards e.g. 'input.zarr/*/*/*'.",
         )(f)
 
     return decorator
@@ -43,7 +44,7 @@ def config_filepath() -> Callable:
             "-c",
             required=True,
             type=click.Path(exists=True, file_okay=True, dir_okay=False),
-            help="Path to YAML configuration file",
+            help="Path to YAML configuration file.",
         )(f)
 
     return decorator
@@ -56,7 +57,7 @@ def transfer_function_dirpath() -> Callable:
             "-t",
             required=True,
             type=click.Path(exists=False, file_okay=False, dir_okay=True),
-            help="Path to transfer function .zarr",
+            help="Path to transfer function .zarr.",
         )(f)
 
     return decorator
@@ -69,7 +70,7 @@ def output_dirpath() -> Callable:
             "-o",
             required=True,
             type=click.Path(exists=False, file_okay=False, dir_okay=True),
-            help="Path to output directory",
+            help="Path to output directory.",
         )(f)
 
     return decorator

--- a/recOrder/cli/parsing.py
+++ b/recOrder/cli/parsing.py
@@ -1,54 +1,75 @@
-import click
+from pathlib import Path
 from typing import Callable
-from iohub.ngff import open_ome_zarr, Plate
+
+import click
+from iohub.ngff import Plate, open_ome_zarr
+from natsort import natsorted
+
+from recOrder.cli.option_eat_all import OptionEatAll
 
 
-def _validate_fov_path(
+def _validate_and_process_paths(
     ctx: click.Context, opt: click.Option, value: str
 ) -> None:
-    dataset = open_ome_zarr(value)
-    if isinstance(dataset, Plate):
-        raise ValueError(
-            "Please supply a single position instead of an HCS plate. Likely fix: replace 'input.zarr' with 'input.zarr/0/0/0'"
-        )
-    return value
+    # Sort and validate the input paths
+    input_paths = [Path(path) for path in natsorted(value)]
+    for path in input_paths:
+        with open_ome_zarr(path, mode="r") as dataset:
+            if isinstance(dataset, Plate):
+                raise ValueError(
+                    "Please supply a single position instead of an HCS plate. Likely fix: replace 'input.zarr' with 'input.zarr/0/0/0'"
+                )
+    return input_paths
 
 
-def input_data_path_argument() -> Callable:
-    def decorator(f: Callable) -> Callable:
-        return click.argument(
-            "input-data-path",
-            type=click.Path(exists=True),
-            callback=_validate_fov_path,
-            nargs=1,
-        )(f)
-
-    return decorator
-
-
-def config_path_option() -> Callable:
+def input_position_dirpaths() -> Callable:
     def decorator(f: Callable) -> Callable:
         return click.option(
-            "--config-path", "-c", required=True, help="Path to config.yml"
+            "--input-position-dirpaths",
+            "-i",
+            cls=OptionEatAll,
+            type=tuple,
+            callback=_validate_and_process_paths,
+            help="Paths to input positions",
         )(f)
 
     return decorator
 
 
-def output_dataset_option(default) -> Callable:
-    click_options = [
-        click.option(
-            "--output-path",
-            "-o",
-            default=default,
-            help="Path to output.zarr",
-        )
-    ]
-    # good place to add chunking, overwrite flag, etc
-
+def config_filepath() -> Callable:
     def decorator(f: Callable) -> Callable:
-        for opt in click_options:
-            f = opt(f)
-        return f
+        return click.option(
+            "--config-filepath",
+            "-c",
+            required=True,
+            type=click.Path(exists=True, file_okay=True, dir_okay=False),
+            help="Path to YAML configuration file",
+        )(f)
+
+    return decorator
+
+
+def transfer_function_dirpath() -> Callable:
+    def decorator(f: Callable) -> Callable:
+        return click.option(
+            "--transfer-function",
+            "-t",
+            required=True,
+            type=click.Path(exists=False, file_okay=False, dir_okay=True),
+            help="Path to transfer function .zarr",
+        )(f)
+
+    return decorator
+
+
+def output_dirpath() -> Callable:
+    def decorator(f: Callable) -> Callable:
+        return click.option(
+            "--output-dirpath",
+            "-o",
+            required=True,
+            type=click.Path(exists=False, file_okay=False, dir_okay=True),
+            help="Path to output directory",
+        )(f)
 
     return decorator

--- a/recOrder/cli/parsing.py
+++ b/recOrder/cli/parsing.py
@@ -22,6 +22,10 @@ def _validate_and_process_paths(
     return input_paths
 
 
+def _str_to_path(ctx: click.Context, opt: click.Option, value: str) -> None:
+    return Path(value)
+
+
 def input_position_dirpaths() -> Callable:
     def decorator(f: Callable) -> Callable:
         return click.option(
@@ -44,6 +48,7 @@ def config_filepath() -> Callable:
             "-c",
             required=True,
             type=click.Path(exists=True, file_okay=True, dir_okay=False),
+            callback=_str_to_path,
             help="Path to YAML configuration file.",
         )(f)
 
@@ -57,6 +62,7 @@ def transfer_function_dirpath() -> Callable:
             "-t",
             required=True,
             type=click.Path(exists=False),
+            callback=_str_to_path,
             help="Path to transfer function .zarr.",
         )(f)
 
@@ -70,6 +76,7 @@ def output_dirpath() -> Callable:
             "-o",
             required=True,
             type=click.Path(exists=False),
+            callback=_str_to_path,
             help="Path to output directory.",
         )(f)
 

--- a/recOrder/cli/parsing.py
+++ b/recOrder/cli/parsing.py
@@ -52,7 +52,7 @@ def config_filepath() -> Callable:
 def transfer_function_dirpath() -> Callable:
     def decorator(f: Callable) -> Callable:
         return click.option(
-            "--transfer-function",
+            "--transfer-function-dirpath",
             "-t",
             required=True,
             type=click.Path(exists=False, file_okay=False, dir_okay=True),

--- a/recOrder/cli/parsing.py
+++ b/recOrder/cli/parsing.py
@@ -10,7 +10,7 @@ from recOrder.cli.option_eat_all import OptionEatAll
 
 def _validate_and_process_paths(
     ctx: click.Context, opt: click.Option, value: str
-) -> None:
+) -> list[Path]:
     # Sort and validate the input paths
     input_paths = [Path(path) for path in natsorted(value)]
     for path in input_paths:
@@ -22,7 +22,7 @@ def _validate_and_process_paths(
     return input_paths
 
 
-def _str_to_path(ctx: click.Context, opt: click.Option, value: str) -> None:
+def _str_to_path(ctx: click.Context, opt: click.Option, value: str) -> Path:
     return Path(value)
 
 

--- a/recOrder/cli/parsing.py
+++ b/recOrder/cli/parsing.py
@@ -56,7 +56,7 @@ def transfer_function_dirpath() -> Callable:
             "--transfer-function-dirpath",
             "-t",
             required=True,
-            type=click.Path(exists=False, file_okay=False, dir_okay=True),
+            type=click.Path(exists=False),
             help="Path to transfer function .zarr.",
         )(f)
 
@@ -69,7 +69,7 @@ def output_dirpath() -> Callable:
             "--output-dirpath",
             "-o",
             required=True,
-            type=click.Path(exists=False, file_okay=False, dir_okay=True),
+            type=click.Path(exists=False),
             help="Path to output directory.",
         )(f)
 

--- a/recOrder/cli/reconstruct.py
+++ b/recOrder/cli/reconstruct.py
@@ -1,20 +1,21 @@
-import click
 import os
-from recOrder.cli.compute_transfer_function import (
-    compute_transfer_function_cli,
-)
+
+import click
+
 from recOrder.cli.apply_inverse_transfer_function import (
     apply_inverse_transfer_function_cli,
 )
+from recOrder.cli.compute_transfer_function import (
+    compute_transfer_function_cli,
+)
 from recOrder.cli.parsing import (
-    input_data_path_argument,
     config_path_option,
+    input_data_path_argument,
     output_dataset_option,
 )
 
 
 @click.command()
-@click.help_option("-h", "--help")
 @input_data_path_argument()
 @config_path_option()
 @output_dataset_option(default="./reconstruction.zarr")
@@ -40,5 +41,7 @@ def reconstruct(input_data_path, config_path, output_path):
         input_data_path, config_path, transfer_function_path
     )
     apply_inverse_transfer_function_cli(
+        input_data_path, transfer_function_path, config_path, output_path
+    )
         input_data_path, transfer_function_path, config_path, output_path
     )

--- a/recOrder/cli/reconstruct.py
+++ b/recOrder/cli/reconstruct.py
@@ -26,6 +26,11 @@ def reconstruct(input_position_dirpaths, config_filepath, output_dirpath):
     convenience function for a `compute-tf` call followed by a `apply-inv-tf`
     call.
 
+    Calculates the transfer function based on the shape of the first position
+    in the list `input-position-dirpaths`, then applies that transfer function
+    to all positions in the list `input-position-dirpaths`, so all positions
+    must have the same TCZYX shape.
+
     See /examples for example configuration files.
 
     >> recorder reconstruct -i ./input.zarr/*/*/* -c ./examples/birefringence.yml -o ./output.zarr

--- a/recOrder/cli/reconstruct.py
+++ b/recOrder/cli/reconstruct.py
@@ -13,13 +13,14 @@ from recOrder.cli.parsing import (
     input_position_dirpaths,
     output_dirpath,
 )
+from recOrder.cli.utils import get_output_paths
 
 
 @click.command()
 @input_position_dirpaths()
 @config_filepath()
 @output_dirpath()
-def reconstruct(input_data_path, config_path, output_path):
+def reconstruct(input_position_dirpaths, config_filepath, output_dirpath):
     """
     Reconstruct a dataset using a configuration file. This is a
     convenience function for a `compute-tf` call followed by a `apply-inv-tf`
@@ -31,15 +32,27 @@ def reconstruct(input_data_path, config_path, output_path):
     """
 
     # Handle transfer function path
-    output_directory = os.path.dirname(output_path)
+    output_directory = os.path.dirname(output_dirpath)
     transfer_function_path = os.path.join(
         output_directory, "transfer_function.zarr"
     )
 
-    # Compute transfer function and apply inverse
+    # Compute transfer function
     compute_transfer_function_cli(
-        input_data_path, config_path, transfer_function_path
+        input_position_dirpaths[0], config_filepath, transfer_function_path
     )
-    apply_inverse_transfer_function_cli(
-        input_data_path, transfer_function_path, config_path, output_path
+
+    # Apply inverse to each position
+    output_position_dirpaths = get_output_paths(
+        input_position_dirpaths, output_dirpath
     )
+
+    for input_position_dirpath, output_position_dirpath in zip(
+        input_position_dirpaths, output_position_dirpaths
+    ):
+        apply_inverse_transfer_function_cli(
+            input_position_dirpath,
+            transfer_function_path,
+            config_filepath,
+            output_position_dirpath,
+        )

--- a/recOrder/cli/reconstruct.py
+++ b/recOrder/cli/reconstruct.py
@@ -9,25 +9,25 @@ from recOrder.cli.compute_transfer_function import (
     compute_transfer_function_cli,
 )
 from recOrder.cli.parsing import (
-    config_path_option,
-    input_data_path_argument,
-    output_dataset_option,
+    config_filepath,
+    input_position_dirpaths,
+    output_dirpath,
 )
 
 
 @click.command()
-@input_data_path_argument()
-@config_path_option()
-@output_dataset_option(default="./reconstruction.zarr")
+@input_position_dirpaths()
+@config_filepath()
+@output_dirpath()
 def reconstruct(input_data_path, config_path, output_path):
-    """Reconstruct a dataset using a configuration file. This is a
+    """
+    Reconstruct a dataset using a configuration file. This is a
     convenience function for a `compute-tf` call followed by a `apply-inv-tf`
     call.
 
     See /examples for example configuration files.
 
-    Example usage:\n
-    $ recorder reconstruct input.zarr/0/0/0 -c /examples/birefringence.yml -o output.zarr
+    >> recorder reconstruct -i ./input.zarr/*/*/* -c ./examples/birefringence.yml -o ./output.zarr
     """
 
     # Handle transfer function path
@@ -41,7 +41,5 @@ def reconstruct(input_data_path, config_path, output_path):
         input_data_path, config_path, transfer_function_path
     )
     apply_inverse_transfer_function_cli(
-        input_data_path, transfer_function_path, config_path, output_path
-    )
         input_data_path, transfer_function_path, config_path, output_path
     )

--- a/recOrder/cli/utils.py
+++ b/recOrder/cli/utils.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+def get_output_paths(
+    input_paths: list[Path], output_zarr_path: Path
+) -> list[Path]:
+    """Generates a mirrored output path list given an input list of positions"""
+    list_output_path = []
+    for path in input_paths:
+        # Select the Row/Column/FOV parts of input path
+        path_strings = Path(path).parts[-3:]
+        # Append the same Row/Column/FOV to the output zarr path
+        list_output_path.append(Path(output_zarr_path, *path_strings))
+    return list_output_path

--- a/recOrder/io/utils.py
+++ b/recOrder/io/utils.py
@@ -1,18 +1,16 @@
-from typing import Literal
-import glob
-import logging
 import os
+import textwrap
+from pathlib import Path
+from typing import Literal
+
+import numpy as np
 import psutil
 import torch
-import textwrap
-import tifffile as tiff
-import numpy as np
 import yaml
 from colorspacious import cspace_convert
 from iohub import open_ome_zarr
 from matplotlib.colors import hsv_to_rgb
 from waveorder.waveorder_reconstructor import waveorder_microscopy
-from recOrder.cli import settings
 
 
 # TO BE DEPRECATED
@@ -239,7 +237,7 @@ def ret_ori_overlay(
     return overlay_final
 
 
-def model_to_yaml(model, yaml_path):
+def model_to_yaml(model, yaml_path: Path) -> None:
     """
     Save a model's dictionary representation to a YAML file.
 
@@ -247,7 +245,7 @@ def model_to_yaml(model, yaml_path):
     ----------
     model : object
         The model object to convert to YAML.
-    yaml_path : str
+    yaml_path : Path
         The path to the output YAML file.
 
     Raises
@@ -268,6 +266,8 @@ def model_to_yaml(model, yaml_path):
     >>> model_to_yaml(model, 'model.yaml')
 
     """
+    yaml_path = Path(yaml_path)
+
     if not hasattr(model, "dict"):
         raise TypeError("The 'model' object does not have a 'dict()' method.")
 
@@ -284,13 +284,13 @@ def model_to_yaml(model, yaml_path):
         )
 
 
-def yaml_to_model(yaml_path, model):
+def yaml_to_model(yaml_path: Path, model):
     """
     Load model settings from a YAML file and create a model instance.
 
     Parameters
     ----------
-    yaml_path : str
+    yaml_path : Path
         The path to the YAML file containing the model settings.
     model : class
         The model class used to create an instance with the loaded settings.
@@ -318,6 +318,8 @@ def yaml_to_model(yaml_path, model):
     >>> model = yaml_to_model('model.yaml', MyModel)
 
     """
+    yaml_path = Path(yaml_path)
+
     if not callable(getattr(model, "__init__", None)):
         raise TypeError(
             "The provided model must be a class with a callable constructor."

--- a/recOrder/tests/cli_tests/test_compute_tf.py
+++ b/recOrder/tests/cli_tests/test_compute_tf.py
@@ -31,7 +31,7 @@ def test_compute_transfer(tmp_path, example_plate):
         [
             "compute-tf",
             "-i",
-            os.path.join(str(plate_path),"A","1","0"),
+            str(plate_path / "A" / "1" / "0"),
             "-c",
             str(config_path),
             "-o",
@@ -78,7 +78,7 @@ def test_compute_transfer_output_file(tmp_path, example_plate):
                 [
                     "compute-tf",
                     "-i",
-                    os.path.join(str(plate_path),"A","1","0"),
+                    str(plate_path / "A" / "1" / "0"),
                     "-c",
                     str(config_path),
                     str(option),

--- a/recOrder/tests/cli_tests/test_compute_tf.py
+++ b/recOrder/tests/cli_tests/test_compute_tf.py
@@ -10,7 +10,7 @@ from recOrder.cli.main import cli
 from recOrder.io import utils
 
 
-def test_compute_transfer(tmp_path, input_zarr):
+def test_compute_transfer(tmp_path, example_plate):
     recon_settings = settings.ReconstructionSettings(
         input_channel_names=[f"State{i}" for i in range(4)],
         reconstruction_dimension=3,
@@ -22,14 +22,14 @@ def test_compute_transfer(tmp_path, input_zarr):
 
     output_path = tmp_path / "output.zarr"
 
-    path, _ = input_zarr
+    plate_path, _ = example_plate
     runner = CliRunner()
     result = runner.invoke(
         cli,
         [
             "compute-tf",
             "-i",
-            str(path),
+            str(plate_path) + "/A/1/0",
             "-c",
             str(config_path),
             "-o",

--- a/recOrder/tests/cli_tests/test_compute_tf.py
+++ b/recOrder/tests/cli_tests/test_compute_tf.py
@@ -132,4 +132,3 @@ def test_fluorescence_write(fluorescence_recon_settings_function):
     assert dataset["optical_transfer_function"].shape == (1, 1, 3, 4, 5)
     assert "real_potential_transfer_function" not in dataset
     assert "imaginary_potential_transfer_function" not in dataset
-    assert "imaginary_potential_transfer_function" not in dataset

--- a/recOrder/tests/cli_tests/test_compute_tf.py
+++ b/recOrder/tests/cli_tests/test_compute_tf.py
@@ -1,3 +1,5 @@
+import os
+
 from click.testing import CliRunner
 
 from recOrder.cli import settings
@@ -29,7 +31,7 @@ def test_compute_transfer(tmp_path, example_plate):
         [
             "compute-tf",
             "-i",
-            str(plate_path) + "/A/1/0",
+            os.path.join(str(plate_path),"A","1","0"),
             "-c",
             str(config_path),
             "-o",
@@ -76,7 +78,7 @@ def test_compute_transfer_output_file(tmp_path, example_plate):
                 [
                     "compute-tf",
                     "-i",
-                    str(plate_path) + "/A/1/0",
+                    os.path.join(str(plate_path),"A","1","0"),
                     "-c",
                     str(config_path),
                     str(option),

--- a/recOrder/tests/cli_tests/test_compute_tf.py
+++ b/recOrder/tests/cli_tests/test_compute_tf.py
@@ -1,12 +1,13 @@
-from recOrder.cli.main import cli
 from click.testing import CliRunner
+
 from recOrder.cli import settings
-from recOrder.io import utils
 from recOrder.cli.compute_transfer_function import (
-    generate_and_save_phase_transfer_function,
     generate_and_save_birefringence_transfer_function,
     generate_and_save_fluorescence_transfer_function,
+    generate_and_save_phase_transfer_function,
 )
+from recOrder.cli.main import cli
+from recOrder.io import utils
 
 
 def test_compute_transfer(tmp_path, input_zarr):
@@ -19,10 +20,21 @@ def test_compute_transfer(tmp_path, input_zarr):
     config_path = tmp_path / "test.yml"
     utils.model_to_yaml(recon_settings, config_path)
 
+    output_path = tmp_path / "output.zarr"
+
     path, _ = input_zarr
     runner = CliRunner()
     result = runner.invoke(
-        cli, ["compute-tf", str(path), "-c", str(config_path)]
+        cli,
+        [
+            "compute-tf",
+            "-i",
+            str(path),
+            "-c",
+            str(config_path),
+            "-o",
+            str(output_path),
+        ],
     )
     assert result.exit_code == 0
 
@@ -45,7 +57,7 @@ def test_compute_transfer_blank_output():
         assert "Error" in result.output
 
 
-def test_compute_transfer_output_file(tmp_path, input_zarr):
+def test_compute_transfer_output_file(tmp_path, example_plate):
     recon_settings = settings.ReconstructionSettings(
         input_channel_names=["BF"],
         reconstruction_dimension=3,
@@ -54,16 +66,17 @@ def test_compute_transfer_output_file(tmp_path, input_zarr):
     config_path = tmp_path / "test.yml"
     utils.model_to_yaml(recon_settings, config_path)
 
-    input_path, _ = input_zarr
+    plate_path, _ = example_plate
     runner = CliRunner()
-    for option in ("-o", "--output-path"):
-        for output_folder in ["test1", "test2/test"]:
+    for option in ("-o", "--output-dirpath"):
+        for output_folder in ["test1.zarr", "test2/test.zarr"]:
             output_path = tmp_path.joinpath(output_folder)
             result = runner.invoke(
                 cli,
                 [
                     "compute-tf",
-                    str(input_path),
+                    "-i",
+                    str(plate_path) + "/A/1/0",
                     "-c",
                     str(config_path),
                     str(option),
@@ -118,4 +131,5 @@ def test_fluorescence_write(fluorescence_recon_settings_function):
     assert dataset["optical_transfer_function"]
     assert dataset["optical_transfer_function"].shape == (1, 1, 3, 4, 5)
     assert "real_potential_transfer_function" not in dataset
+    assert "imaginary_potential_transfer_function" not in dataset
     assert "imaginary_potential_transfer_function" not in dataset

--- a/recOrder/tests/cli_tests/test_reconstruct.py
+++ b/recOrder/tests/cli_tests/test_reconstruct.py
@@ -73,7 +73,7 @@ def test_reconstruct(tmp_path):
             [
                 "compute-tf",
                 "-i",
-                os.path.join(str(input_path), "0", "0", "0"),
+                str(input_path / "0" / "0" / "0"),
                 "-c",
                 str(config_path),
                 "-o",
@@ -91,7 +91,7 @@ def test_reconstruct(tmp_path):
             [
                 "apply-inv-tf",
                 "-i",
-                os.path.join(str(input_path), "0", "0", "0"),
+                str(input_path / "0" / "0" / "0"),
                 "-t",
                 str(tf_path),
                 "-c",
@@ -106,7 +106,7 @@ def test_reconstruct(tmp_path):
         assert "Reconstructing" in result_inv.output
 
         # Check output
-        result_dataset = open_ome_zarr(os.path.join(str(result_path), "0", "0", "0"))
+        result_dataset = open_ome_zarr(str(result_path / "0" / "0" / "0"))
         assert result_dataset["0"].shape[0] == time_length_target
         assert result_dataset["0"].shape[3:] == (5, 6)
 
@@ -116,7 +116,7 @@ def test_reconstruct(tmp_path):
             [
                 "reconstruct",
                 "-i",
-                os.path.join(str(input_path), "0", "0", "0"),
+                str(input_path / "0" / "0" / "0"),
                 "-c",
                 str(config_path),
                 "-o",

--- a/recOrder/tests/cli_tests/test_reconstruct.py
+++ b/recOrder/tests/cli_tests/test_reconstruct.py
@@ -15,12 +15,14 @@ def test_reconstruct(tmp_path):
     channel_names = [f"State{x}" for x in range(4)]
     dataset = open_ome_zarr(
         input_path,
-        layout="fov",
+        layout="hcs",
         mode="w",
         channel_names=channel_names,
     )
+
+    position = dataset.create_position("0", "0", "0")
     input_scale = [1, 2, 3, 4, 5]
-    dataset.create_zeros(
+    position.create_zeros(
         "0",
         (5, 4, 4, 5, 6),
         dtype=np.uint16,
@@ -68,7 +70,8 @@ def test_reconstruct(tmp_path):
             cli,
             [
                 "compute-tf",
-                str(input_path),
+                "-i",
+                str(input_path) + "/0/0/0",
                 "-c",
                 str(config_path),
                 "-o",
@@ -85,7 +88,9 @@ def test_reconstruct(tmp_path):
             cli,
             [
                 "apply-inv-tf",
-                str(input_path),
+                "-i",
+                str(input_path) + "/0/0/0",
+                "-t",
                 str(tf_path),
                 "-c",
                 str(config_path),
@@ -94,12 +99,12 @@ def test_reconstruct(tmp_path):
             ],
             catch_exceptions=False,
         )
-        assert result_path.exists()
         assert result_inv.exit_code == 0
+        assert result_path.exists()
         assert "Reconstructing" in result_inv.output
 
         # Check output
-        result_dataset = open_ome_zarr(result_path)
+        result_dataset = open_ome_zarr(str(result_path) + "/0/0/0")
         assert result_dataset["0"].shape[0] == time_length_target
         assert result_dataset["0"].shape[3:] == (5, 6)
 
@@ -108,7 +113,8 @@ def test_reconstruct(tmp_path):
             cli,
             [
                 "reconstruct",
-                str(input_path),
+                "-i",
+                str(input_path) + "/0/0/0/",
                 "-c",
                 str(config_path),
                 "-o",

--- a/recOrder/tests/cli_tests/test_reconstruct.py
+++ b/recOrder/tests/cli_tests/test_reconstruct.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 from click.testing import CliRunner
 from iohub.ngff import open_ome_zarr
@@ -71,7 +73,7 @@ def test_reconstruct(tmp_path):
             [
                 "compute-tf",
                 "-i",
-                str(input_path) + "/0/0/0",
+                os.path.join(str(input_path), "0", "0", "0"),
                 "-c",
                 str(config_path),
                 "-o",
@@ -89,7 +91,7 @@ def test_reconstruct(tmp_path):
             [
                 "apply-inv-tf",
                 "-i",
-                str(input_path) + "/0/0/0",
+                os.path.join(str(input_path), "0", "0", "0"),
                 "-t",
                 str(tf_path),
                 "-c",
@@ -114,7 +116,7 @@ def test_reconstruct(tmp_path):
             [
                 "reconstruct",
                 "-i",
-                str(input_path) + "/0/0/0/",
+                os.path.join(str(input_path), "0", "0", "0"),
                 "-c",
                 str(config_path),
                 "-o",

--- a/recOrder/tests/cli_tests/test_reconstruct.py
+++ b/recOrder/tests/cli_tests/test_reconstruct.py
@@ -106,7 +106,7 @@ def test_reconstruct(tmp_path):
         assert "Reconstructing" in result_inv.output
 
         # Check output
-        result_dataset = open_ome_zarr(str(result_path) + "/0/0/0")
+        result_dataset = open_ome_zarr(os.path.join(str(result_path), "0", "0", "0"))
         assert result_dataset["0"].shape[0] == time_length_target
         assert result_dataset["0"].shape[3:] == (5, 6)
 

--- a/recOrder/tests/conftest.py
+++ b/recOrder/tests/conftest.py
@@ -1,21 +1,32 @@
-import pytest
 import numpy as np
-from recOrder.cli import settings
+import pytest
 from iohub.ngff import open_ome_zarr
+
+from recOrder.cli import settings
 
 
 @pytest.fixture(scope="function")
-def input_zarr(tmp_path):
-    path = tmp_path / "input.zarr"
+def example_plate(tmp_path):
+    plate_path = tmp_path / "input.zarr"
 
-    dataset = open_ome_zarr(
-        path,
-        layout="fov",
+    position_list = (
+        ("A", "1", "0"),
+        ("B", "1", "0"),
+        ("B", "2", "0"),
+    )
+
+    plate_dataset = open_ome_zarr(
+        plate_path,
+        layout="hcs",
         mode="w",
         channel_names=[f"State{i}" for i in range(4)] + ["BF"],
     )
-    dataset.create_zeros("0", (2, 5, 4, 5, 6), dtype=np.uint16)
-    yield path, dataset
+
+    for row, col, fov in position_list:
+        position = plate_dataset.create_position(row, col, fov)
+        position.create_zeros("0", (2, 5, 4, 5, 6), dtype=np.uint16)
+
+    yield plate_path, plate_dataset
 
 
 @pytest.fixture(scope="function")
@@ -45,4 +56,5 @@ def fluorescence_recon_settings_function(tmp_path):
         mode="w",
         channel_names=[f"State{i}" for i in range(4)],
     )
+    yield recon_settings, dataset
     yield recon_settings, dataset

--- a/recOrder/tests/conftest.py
+++ b/recOrder/tests/conftest.py
@@ -57,4 +57,3 @@ def fluorescence_recon_settings_function(tmp_path):
         channel_names=[f"State{i}" for i in range(4)],
     )
     yield recon_settings, dataset
-    yield recon_settings, dataset


### PR DESCRIPTION
This PR changes recOrder's CLI signatures to:

```
recorder reconstruct `
    -i ./data.zarr/*/*/* `
    -c ./config.yml `
    -o ./reconstruction.zarr

recorder compute-tf `
    -i ./data.zarr/0/0/0 `
    -c ./config.yml `
    -o ./tf.zarr

recorder apply-inv-tf 
    -i ./data.zarr/*/*/* `
    -t ./tf.zarr `
    -c ./config.yml `
    -o ./reconstruction.zarr
```

This PR is an important step towards solving #396, so I'm tagging @edyoshikun. 

These standards match the recent changes to the mantis repo. There is some duplication in the `parsing.py`, `utils.py`, and `option_eat_all.py` files between `recOrder` and `mantis`, but after the next recOrder release we'll delete the duplication from the mantis repo.

This PR potentially affects the GUI, so I did a quick test on hummingbird to confirm all reconstructions still run.  