### PR TITLE
Skip `QFileDialog.Options()`

### DIFF
--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -2367,9 +2367,7 @@ class MainWidget(QWidget):
 
         """
 
-        options = QFileDialog.Options()
-
-        options |= QFileDialog.DontUseNativeDialog
+        options = QFileDialog.DontUseNativeDialog
         if type == "dir":
             path = QFileDialog.getExistingDirectory(
                 None, title, ref, options=options


### PR DESCRIPTION
Fixes #403.

In [PyQt5, `QFileDialog` has a class called `Options` that stores existing options.](https://www.riverbankcomputing.com/static/Docs/PyQt5/api/qtwidgets/qfiledialog.html#qfiledialog) 
In [PyQt6, this class seems to have disappeared](https://www.riverbankcomputing.com/static/Docs/PyQt6/api/qtwidgets/qfiledialog.html#qfiledialog), although `QFileDialog.Options()` calls still appear further down the docs page (?).

This two-line fix seems to have fixed the issue on hummingbird, where I tested the "Browse" buttons and "Load calibration".  

We don't set options anywhere else, so I don't expect any changes to the previous behavior. 