### PR TITLE
CLI creates empty HCS zarr then fills it

### DIFF
--- a/recOrder/acq/acquisition_workers.py
+++ b/recOrder/acq/acquisition_workers.py
@@ -20,7 +20,7 @@ from recOrder.acq.acq_functions import (
 )
 from recOrder.cli import settings
 from recOrder.cli.apply_inverse_transfer_function import (
-    apply_inverse_transfer_function_cli,
+    apply_inverse_transfer_function_single_position,
 )
 from recOrder.cli.compute_transfer_function import (
     compute_transfer_function_cli,
@@ -304,7 +304,7 @@ class BFAcquisitionWorker(WorkerBase):
             output_dirpath=transfer_function_path,
         )
 
-        apply_inverse_transfer_function_cli(
+        apply_inverse_transfer_function_single_position(
             input_position_dirpath=input_data_path,
             transfer_function_dirpath=transfer_function_path,
             config_filepath=self.config_path,
@@ -636,7 +636,7 @@ class PolarizationAcquisitionWorker(WorkerBase):
             output_dirpath=transfer_function_path,
         )
 
-        apply_inverse_transfer_function_cli(
+        apply_inverse_transfer_function_single_position(
             input_position_dirpath=input_data_path,
             transfer_function_dirpath=transfer_function_path,
             config_filepath=self.config_path,

--- a/recOrder/calib/calibration_workers.py
+++ b/recOrder/calib/calibration_workers.py
@@ -17,7 +17,7 @@ from qtpy.QtCore import Signal
 from recOrder.calib.Calibration import LC_DEVICE_NAME
 from recOrder.cli import settings
 from recOrder.cli.apply_inverse_transfer_function import (
-    apply_inverse_transfer_function_cli,
+    apply_inverse_transfer_function_single_position,
 )
 from recOrder.cli.compute_transfer_function import (
     compute_transfer_function_cli,
@@ -377,7 +377,7 @@ class BackgroundCaptureWorker(
             output_dirpath=transfer_function_path,
         )
 
-        apply_inverse_transfer_function_cli(
+        apply_inverse_transfer_function_single_position(
             input_position_dirpath=input_data_path,
             transfer_function_dirpath=transfer_function_path,
             config_filepath=reconstruction_config_path,

--- a/recOrder/cli/reconstruct.py
+++ b/recOrder/cli/reconstruct.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import click
 
@@ -13,7 +13,6 @@ from recOrder.cli.parsing import (
     input_position_dirpaths,
     output_dirpath,
 )
-from recOrder.cli.utils import get_output_paths
 
 
 @click.command()
@@ -37,27 +36,21 @@ def reconstruct(input_position_dirpaths, config_filepath, output_dirpath):
     """
 
     # Handle transfer function path
-    output_directory = os.path.dirname(output_dirpath)
-    transfer_function_path = os.path.join(
-        output_directory, "transfer_function.zarr"
+    transfer_function_path = output_dirpath.parent / Path(
+        "transfer_function.zarr"
     )
 
     # Compute transfer function
     compute_transfer_function_cli(
-        input_position_dirpaths[0], config_filepath, transfer_function_path
+        input_position_dirpaths[0],
+        config_filepath,
+        transfer_function_path,
     )
 
-    # Apply inverse to each position
-    output_position_dirpaths = get_output_paths(
-        input_position_dirpaths, output_dirpath
+    # Apply inverse transfer function
+    apply_inverse_transfer_function_cli(
+        input_position_dirpaths,
+        transfer_function_path,
+        config_filepath,
+        output_dirpath,
     )
-
-    for input_position_dirpath, output_position_dirpath in zip(
-        input_position_dirpaths, output_position_dirpaths
-    ):
-        apply_inverse_transfer_function_cli(
-            input_position_dirpath,
-            transfer_function_path,
-            config_filepath,
-            output_position_dirpath,
-        )

--- a/recOrder/cli/utils.py
+++ b/recOrder/cli/utils.py
@@ -1,14 +1,36 @@
 from pathlib import Path
+from typing import Tuple
+
+from iohub.ngff import open_ome_zarr
+from iohub.ngff_meta import TransformationMeta
+from numpy.typing import DTypeLike
 
 
-def get_output_paths(
-    input_paths: list[Path], output_zarr_path: Path
-) -> list[Path]:
-    """Generates a mirrored output path list given an input list of positions"""
-    list_output_path = []
-    for path in input_paths:
-        # Select the Row/Column/FOV parts of input path
-        path_strings = Path(path).parts[-3:]
-        # Append the same Row/Column/FOV to the output zarr path
-        list_output_path.append(Path(output_zarr_path, *path_strings))
-    return list_output_path
+def create_empty_hcs_zarr(
+    store_path: Path,
+    position_keys: list[Tuple[str]],
+    shape: Tuple[int],
+    chunks: Tuple[int],
+    scale: Tuple[float],
+    channel_names: list[str],
+    dtype: DTypeLike,
+) -> None:
+    """Create an empty zarr plate, appending position if they do not exist"""
+
+    # Create plate
+    output_plate = open_ome_zarr(
+        str(store_path), layout="hcs", mode="a", channel_names=channel_names
+    )
+
+    # Create positions
+    for position_key in position_keys:
+        if "/".join(position_key) not in output_plate.zgroup:
+            position = output_plate.create_position(*position_key)
+
+            _ = position.create_zeros(
+                name="0",
+                shape=shape,
+                chunks=chunks,
+                dtype=dtype,
+                transform=[TransformationMeta(type="scale", scale=scale)],
+            )

--- a/recOrder/tests/util_tests/test_create_empty.py
+++ b/recOrder/tests/util_tests/test_create_empty.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+import numpy as np
+from iohub import open_ome_zarr
+
+from recOrder.cli.utils import create_empty_hcs_zarr
+
+
+def test_create_empty_hcs_zarr():
+    store_path = Path("test_store.zarr")
+    position_keys = [
+        ("A", "0", "3"),
+        ("B", "10", "4"),
+    ]
+    shape = (1, 1, 1, 1024, 1024)
+    chunks = (1, 1, 1, 256, 256)
+    scale = (1, 1, 1, 0.5, 0.5)
+    channel_names = ["Channel1", "Channel2"]
+    dtype = np.uint16
+
+    create_empty_hcs_zarr(
+        store_path, position_keys, shape, chunks, scale, channel_names, dtype
+    )
+
+    # Verify existence of positions and channels
+    with open_ome_zarr(store_path, mode="r") as z:
+        for position_key in position_keys:
+            position_path = "/".join(position_key)
+            assert position_path in z.zgroup
+            assert "Channel1" in z.channel_names
+            assert "Channel2" in z.channel_names
+
+    # Repeat creation should not fail
+    create_empty_hcs_zarr(
+        store_path, position_keys, shape, chunks, scale, channel_names, dtype
+    )


### PR DESCRIPTION
Fixes #407, and makes progress towards #396. 

This PR refactors `apply_inverse_transfer_function` so that a complete HCS plate is created in advance then filled. 

@edyoshikun I've changed (and hopefully simplified) some of the logic you were using on the mantis side...see `apply_inverse_transfer_function.py L405-L425`. I'm getting all of the reconstruction-specific metadata, using it to create an empty HCS zarr, then looping through the input positions, inverting and writing as I go. 

I expect/hope that reconstruction-specific metadata can be swapped for deskew-specific or other metadata, and that this pattern is compatible with multiprocessing.