### PR TITLE
Birefringence overlays on top

### DIFF
--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -1172,30 +1172,29 @@ class MainWidget(QWidget):
 
     def handle_layers_updated(self, event: Event):
         layers: LayerList = event.source
-        latest_layer_name = layers[-1].name
-        channels = ["Retardance", "Orientation"]
-        for ch in channels:
-            if latest_layer_name.startswith(ch):
-                suffix = latest_layer_name.replace(ch, "")
-                other_name = channels[1 - channels.index(ch)] + suffix
+        for layer in layers:
+            if layer.name.startswith("Orientation"):
+                orientation_name = layer.name
+                suffix = orientation_name.replace("Orientation", "")
+                retardance_name = "Retardance" + suffix
                 overlay_name = "BirefringenceOverlay" + suffix
-                if other_name in layers and overlay_name not in layers:
+                if retardance_name in layers:
                     logging.info(
                         "Detected updated birefringence layers: "
-                        f"'{latest_layer_name}', '{other_name}'"
+                        f"'{retardance_name}', '{orientation_name}'"
                     )
                     self._draw_bire_overlay(
-                        [ch + suffix, other_name], overlay_name
+                        retardance_name, orientation_name, overlay_name
                     )
-        if latest_layer_name.startswith(channels[1]):
-            logging.info(
-                "Detected orientation layer in updated layer list."
-                "Setting its colormap to HSV."
-            )
-            self.viewer.layers[latest_layer_name].colormap = "hsv"
+
+                logging.info(
+                    "Detected orientation layer in updated layer list."
+                    "Setting its colormap to HSV."
+                )
+                self.viewer.layers[orientation_name].colormap = "hsv"
 
     def _draw_bire_overlay(
-        self, source_names: list[str, str], overlay_name: str
+        self, retardance_name: str, orientation_name: str, overlay_name: str
     ):
         def _layer_data(name: str):
             return self.viewer.layers[name].data
@@ -1203,7 +1202,6 @@ class MainWidget(QWidget):
         def _draw(overlay):
             self._add_or_update_image_layer(overlay, overlay_name, cmap="rgb")
 
-        orientation_name, retardance_name = sorted(source_names)
         retardance = _layer_data(retardance_name)
         orientation = _layer_data(orientation_name)
         worker = create_worker(

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -1172,30 +1172,28 @@ class MainWidget(QWidget):
 
     def handle_layers_updated(self, event: Event):
         layers: LayerList = event.source
-        # starting with the most recently added layers
-        for layer in reversed(layers):
-            # find a layer name that starts with "Orientation"
-            if layer.name.startswith("Orientation"):
-                orientation_name = layer.name
-                suffix = orientation_name.replace("Orientation", "")
-                retardance_name = "Retardance" + suffix
-                overlay_name = "BirefringenceOverlay" + suffix
-                # if the matching retardance layer is present, generate an overlay
-                if retardance_name in layers:
-                    logging.info(
-                        "Detected updated birefringence layers: "
-                        f"'{retardance_name}', '{orientation_name}'"
-                    )
-                    self._draw_bire_overlay(
-                        retardance_name, orientation_name, overlay_name
-                    )
-
-                # always display layers that start with "Orientation" in hsv
+        # if the first channel starts with "Orientation"
+        if layers[-1].name.startswith("Orientation"):
+            orientation_name = layers[-1].name
+            suffix = orientation_name.replace("Orientation", "")
+            retardance_name = "Retardance" + suffix
+            overlay_name = "BirefringenceOverlay" + suffix
+            # if the matching retardance layer is present, generate an overlay
+            if retardance_name in layers:
                 logging.info(
-                    "Detected orientation layer in updated layer list."
-                    "Setting its colormap to HSV."
+                    "Detected updated birefringence layers: "
+                    f"'{retardance_name}', '{orientation_name}'"
                 )
-                self.viewer.layers[orientation_name].colormap = "hsv"
+                self._draw_bire_overlay(
+                    retardance_name, orientation_name, overlay_name
+                )
+
+            # always display layers that start with "Orientation" in hsv
+            logging.info(
+                "Detected orientation layer in updated layer list."
+                "Setting its colormap to HSV."
+            )
+            self.viewer.layers[orientation_name].colormap = "hsv"
 
     def _draw_bire_overlay(
         self, retardance_name: str, orientation_name: str, overlay_name: str

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -1172,12 +1172,15 @@ class MainWidget(QWidget):
 
     def handle_layers_updated(self, event: Event):
         layers: LayerList = event.source
-        for layer in layers:
+        # starting with the most recently added layers
+        for layer in reversed(layers):
+            # find a layer name that starts with "Orientation"
             if layer.name.startswith("Orientation"):
                 orientation_name = layer.name
                 suffix = orientation_name.replace("Orientation", "")
                 retardance_name = "Retardance" + suffix
                 overlay_name = "BirefringenceOverlay" + suffix
+                # if the matching retardance layer is present, generate an overlay
                 if retardance_name in layers:
                     logging.info(
                         "Detected updated birefringence layers: "
@@ -1187,6 +1190,7 @@ class MainWidget(QWidget):
                         retardance_name, orientation_name, overlay_name
                     )
 
+                # always display layers that start with "Orientation" in hsv
                 logging.info(
                     "Detected orientation layer in updated layer list."
                     "Setting its colormap to HSV."

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -1171,6 +1171,15 @@ class MainWidget(QWidget):
         )
 
     def handle_layers_updated(self, event: Event):
+        """Whenever a layer is inserted or moved, we check if the top layer
+        starts with 'Orientation*'. If it is, we search for a layer that starts
+        with 'Retardance*' and has the same suffix as 'Orientation*', then use the
+        'Orientation*'-'Retardance*' pair to generate a 'BirefringenceOverlay*'
+        layer.
+
+        We also color the 'Orientation*' layer in an HSV colormap.
+        """
+
         layers: LayerList = event.source
         # if the first channel starts with "Orientation"
         if layers[-1].name.startswith("Orientation"):


### PR DESCRIPTION
Fixes #406.

This PR puts a newly generated birefringence overlay as the top layer (for new acquisitions and dragged-in zarr stores). 

The previous logic would only update the birefringence overlay if it did not already exist. This failed to trigger during repeat `recOrder` acquisitions, which write to the birefringence overlay in place so it always exists. 

The new logic only updates the birefringence overlay when the last layer starts with "Orientation", which always follows "Retardance" in the layer order. This logic prevents "mixed updating" bugs where the overlay generation happens with the orientation from one dataset and the retardance from the previous dataset. 

Tested on hummingbird.