### PR TITLE
Do not convert scale metadata from micromanager

### DIFF
--- a/recOrder/acq/acquisition_workers.py
+++ b/recOrder/acq/acquisition_workers.py
@@ -354,6 +354,7 @@ class BFAcquisitionWorker(WorkerBase):
                         os.path.join(dir_, prefix),
                         self.latest_out_path,
                         data_type="ometiff",
+                        scale_voxels=False,
                         grid_layout=False,
                     )
                     converter.run()


### PR DESCRIPTION
Possible fix for #418.

`iohub convert` now passes scale metadata by default, which means that micromanager's pixel sizes get saved into the scale metadata. 

This means that `recOrder` now has two sources of truth for it's scale metadata: the scale metadata of the input zarr and the scale metadata that the user enters in the "pixel size" and "magnification" textboxes. This causes problems because the `ome-zarr` reader treats the zarr's scale metadata as truth, so when you try to compare data from the GUI to data from a file the scale is incorrect: see #418. 

I can see two ways to solve this:
1. **Treat the zarr scale metadata as truth.** This would mean removing the "pixel size" and "magnification" fields from the recOrder GUI, removing the `yx_pixel_size` field from `recOrder` CLI, and forcing all `recOrder==0.4.0` sessions to set the correct pixel size in the micromanager's pixel size calibration tool. This is a reasonably large change. 

2. **Continue to treat the recOrder GUI as truth and do not pass scale metadata through `iohub convert`.** This is the one-line fix implemented here. This means that scales will be [1,1,1,1,1] throughout recOrder sessions. This means that you can easily compare everything, so it "fixes" #418. 

I am leaning towards solution 2 for `recOrder==0.4.0`, and we can use solution 1 for `recOrder==1.0.0`.  

Note: `recorder reconstruct` will continue to pass its input metadata through to the output, so `mantis` can continue to use `recorder reconstruct`. 