### PR TITLE
Check for PyQt5

### DIFF
--- a/recOrder/__init__.py
+++ b/recOrder/__init__.py
@@ -1,0 +1,11 @@
+# qtpy defaults to PyQt5/PySide2 which can be present in upgraded environments
+import qtpy
+
+if qtpy.PYQT5:
+    raise RuntimeError(
+        "Please remove PyQt5 from your environment with `pip uninstall PyQt5`"
+    )
+elif qtpy.PYSIDE2:
+    raise RuntimeError(
+        "Please remove PySide2 from your environment with `pip uninstall PySide2`"
+    )


### PR DESCRIPTION
Fixes #409.

I tried checking imports like @ziw-liu suggesting, but after `pip uninstall PyQt5` I was still able to `import PyQt5`. The environment variable also failed. 

I tested this solution on hummingbird. 