### PR TITLE
`recOrder` data schema

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 **I would like to use the `napari plugin`:** start with the [plugin guide](./napari-plugin-guide.md).
 
-**I would like to automate my reconstructions:** start with the [reconstruction guide](./reconstruction-guide.md).
+**I would like to automate my reconstructions:** start with the [reconstruction guide](./reconstruction-guide.md) and use the [data schema](./data-schema.md).
 
 **I would like to watch an experienced user introduce `recOrder` (out of date)**: [watch the tutorial](https://drive.google.com/file/d/1tHLHZ_uUnddb3jzXnQUjUiynSDS8XIy2/view?usp=sharing). 
 

--- a/docs/data-schema.md
+++ b/docs/data-schema.md
@@ -8,15 +8,15 @@ Currently, we structure raw data in the following hierarchy:
 
 ```text
 working_directory/                      # commonly YYYY_MM_DD_exp_name, but not enforced
-├── calibration_metadata_0.txt        
+├── polarization_calibration_0.txt        
 │   ...
-├── calibration_metadata_<i>.txt         # i calibration repeats
+├── polarization_calibration_<i>.txt    # i calibration repeats
 │
 ├── bg_0
 │   ...
 ├── bg_<j>                              # j background repeats
 │   ├── background.zarr             
-│   ├── calibration_metadata.txt        # copied into each bg folder 
+│   ├── polarization_calibration.txt    # copied into each bg folder 
 │   ├── reconstruction.zarr
 │   ├── reconstruction_settings.yml     # for use with `recorder reconstruct`
 │   └── transfer_function.zarr          # for use with `recorder apply-inv-tf`

--- a/docs/data-schema.md
+++ b/docs/data-schema.md
@@ -8,41 +8,37 @@ Currently, we structure raw data in the following hierarchy:
 
 ```text
 working_directory/                      # commonly YYYY_MM_DD_exp_name, but not enforced
-├── calibration_metadata.txt        
+├── calibration_metadata_0.txt        
 │   ...
-├── calibration_metadata<i>.txt         # i calibration repeats
+├── calibration_metadata_<i>.txt         # i calibration repeats
 │
-├── BG
+├── bg_0
 │   ...
-├── BG_<j>                              # j background repeats
+├── bg_<j>                              # j background repeats
 │   ├── background.zarr             
-│   ├── calibration_metadata.txt        # duplicated for each BG
-│   ├── gui_state.yml               
+│   ├── calibration_metadata.txt        # copied into each bg folder 
 │   ├── reconstruction.zarr
 │   ├── reconstruction_settings.yml     # for use with `recorder reconstruct`
 │   └── transfer_function.zarr          # for use with `recorder apply-inv-tf`
 │
-├── <acq_name_0>_recOrderPluginSnap_0   
-├── <acq_name_0>_recOrderPluginSnap_1 
-│   ├── <acq_name_0>_RawPolDataSnap.zarr
-│   ├── gui_state.yml
+├── <acq_name_0>_snap_0   
+├── <acq_name_0>_snap_1 
+│   ├── raw_data.zarr
 │   ├── reconstruction.zarr
 │   ├── reconstruction_settings.yml
 │   └── transfer_function.zarr
 │   ...
-├── <acq_name_0>_recOrderPluginSnap_<k> # k repeats with the first acquisition name
-│   ├── <acq_name_0>_RawBFDataSnap.zarr # note mixed Pol and BF data with same acquisition name
-│   ├── gui_state.yml
+├── <acq_name_0>_snap_<k>               # k repeats with the first acquisition name
+│   ├── raw_data.zarr          
 │   ├── reconstruction.zarr
 │   ├── reconstruction_settings.yml
 │   └── transfer_function.zarr
 │   ...
 │
-├── <acq_name_l>_recOrderPluginSnap_0   # l different acquisition names
+├── <acq_name_l>_snap_0                 # l different acquisition names
 │   ...
-├── <acq_name_l>_recOrderPluginSnap_<m> $ m repeats for this acquisition name
-    ├── <acq_name_l>_RawBFDataSnap.zarr 
-    ├── gui_state.yml
+├── <acq_name_l>_snap_<m>               # m repeats for this acquisition name
+    ├── raw_data.zarr 
     ├── reconstruction.zarr
     ├── reconstruction_settings.yml
     └── transfer_function.zarr

--- a/docs/data-schema.md
+++ b/docs/data-schema.md
@@ -47,3 +47,5 @@ working_directory/                      # commonly YYYY_MM_DD_exp_name, but not 
     ├── reconstruction_settings.yml
     └── transfer_function.zarr
 ```
+
+Each `.zarr` contains an [OME-NGFF v0.4](https://ngff.openmicroscopy.org/0.4/) in HCS format with a single field of view. 

--- a/docs/data-schema.md
+++ b/docs/data-schema.md
@@ -1,0 +1,49 @@
+# Data schema
+
+This document defines the standard for data acquired with `recOrder`.
+
+## Raw directory organization
+
+Currently, we structure raw data in the following hierarchy:
+
+```text
+working_directory/                      # commonly YYYY_MM_DD_exp_name, but not enforced
+├── calibration_metadata.txt        
+│   ...
+├── calibration_metadata<i>.txt         # i calibration repeats
+│
+├── BG
+│   ...
+├── BG_<j>                              # j background repeats
+│   ├── background.zarr             
+│   ├── calibration_metadata.txt        # duplicated for each BG
+│   ├── gui_state.yml               
+│   ├── reconstruction.zarr
+│   ├── reconstruction_settings.yml     # for use with `recorder reconstruct`
+│   └── transfer_function.zarr          # for use with `recorder apply-inv-tf`
+│
+├── <acq_name_0>_recOrderPluginSnap_0   
+├── <acq_name_0>_recOrderPluginSnap_1 
+│   ├── <acq_name_0>_RawPolDataSnap.zarr
+│   ├── gui_state.yml
+│   ├── reconstruction.zarr
+│   ├── reconstruction_settings.yml
+│   └── transfer_function.zarr
+│   ...
+├── <acq_name_0>_recOrderPluginSnap_<k> # k repeats with the first acquisition name
+│   ├── <acq_name_0>_RawBFDataSnap.zarr # note mixed Pol and BF data with same acquisition name
+│   ├── gui_state.yml
+│   ├── reconstruction.zarr
+│   ├── reconstruction_settings.yml
+│   └── transfer_function.zarr
+│   ...
+│
+├── <acq_name_l>_recOrderPluginSnap_0   # l different acquisition names
+│   ...
+├── <acq_name_l>_recOrderPluginSnap_<m> $ m repeats for this acquisition name
+    ├── <acq_name_l>_RawBFDataSnap.zarr 
+    ├── gui_state.yml
+    ├── reconstruction.zarr
+    ├── reconstruction_settings.yml
+    └── transfer_function.zarr
+```


### PR DESCRIPTION
Fixes #371 

This PR describes `recOrder`'s current storage schema for discussion. Let's iterate on the schema here, then after this merges I will modify `recOrder` to match the schema. 

Here's a list of the issues I think should be addressed together with my suggestions:
- **consistent numbering:** I'll vote for the first `BG` to be `BG_0` to match the snaps
- **consistent case:** I'll vote for snake_case everywhere, so `BG` -> `bg`, `recOrderPluginSnap` -> `recorder_plugin_snap` and `<acq_name_0>_RawPolDataSnap.zarr` -> `<acq_name_0>_data.zarr`
- **simpler names:** I'll vote for `<acq_name_0>_recOrderPluginSnap` -> `<acq_name_0>_snap`, and `<acq_name_0>_RawPolDataSnap.zarr` -> `<acq_name_0>_raw_data.zarr`
- **consistent path to raw data**: we currently save polarization data to `*_RawPolDataSnap` and brightfield data to `*_RawBFDataSnap`. The channel names within these zarr stores describe the data within (`'BF'`, `'State*'`), so this data is redundant. (I'm flexible on this point, but if we prefer separate names then I think the names should appear one level up...as is they're hidden in the root directory).  
- **consistent duplication of `<acq_name>`**: I will vote for `<acq_name_0>_RawPolDataSnap.zarr` -> `RawPolDataSnap.zarr`, but I'm also fine with the alternative of prepending `<acq_name_0>` to the other files (`reconstruction.zarr`, `transfer_function.zarr`, etc) 