### PR TITLE
Background scaling, naming, and squeezing

### DIFF
--- a/recOrder/calib/Calibration.py
+++ b/recOrder/calib/Calibration.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from importlib_metadata import version
 from iohub import open_ome_zarr
+from iohub.ngff_meta import TransformationMeta
 from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable
 from napari.utils.notifications import show_warning
 from scipy.interpolate import interp1d
@@ -1091,8 +1092,6 @@ class QLIPP_Calibration:
             channel_names=[f"State{i}" for i in range(num_states)],
         ) as dataset:
             position = dataset.create_position("0", "0", "0")
-            from iohub.ngff_meta import TransformationMeta
-
             position.create_zeros(
                 name="0",
                 shape=(1, num_states, 1, cyx_data.shape[1], cyx_data.shape[2]),

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -1154,6 +1154,7 @@ class MainWidget(QWidget):
         move_to_top : bool, optional
             whether to move the updated layer to the top of layers list, by default True
         """
+        image = np.squeeze(image)
         scale = scale[-image.ndim :]  # match shapes
 
         if name in self.viewer.layers:

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -1154,7 +1154,8 @@ class MainWidget(QWidget):
         move_to_top : bool, optional
             whether to move the updated layer to the top of layers list, by default True
         """
-        image = np.squeeze(image)
+        if image.shape[0] == 1:
+            image = image.squeeze(axis=0)
         scale = scale[-image.ndim :]  # match shapes
 
         if name in self.viewer.layers:

--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -1181,16 +1181,16 @@ class MainWidget(QWidget):
     @Slot(tuple)
     def handle_bg_image_update(self, value):
         data, scale = value
-        self._add_or_update_image_layer(data, "Background Images", scale=scale)
+        self._add_or_update_image_layer(data, "Raw Background", scale=scale)
 
     @Slot(tuple)
     def handle_bg_bire_image_update(self, value):
         data, scale = value
         self._add_or_update_image_layer(
-            data[0], "Background Retardance", scale=scale
+            data[0], "Retardance Background", scale=scale
         )
         self._add_or_update_image_layer(
-            data[1], "Background Orientation", cmap="hsv", scale=scale
+            data[1], "Orientation Background", cmap="hsv", scale=scale
         )
 
     def handle_layers_updated(self, event: Event):
@@ -1209,7 +1209,7 @@ class MainWidget(QWidget):
             orientation_name = layers[-1].name
             suffix = orientation_name.replace("Orientation", "")
             retardance_name = "Retardance" + suffix
-            overlay_name = "BirefringenceOverlay" + suffix
+            overlay_name = "Birefringence Overlay" + suffix
             # if the matching retardance layer is present, generate an overlay
             if retardance_name in layers:
                 logging.info(


### PR DESCRIPTION
This PR makes several QOL improvements to the backgrounds in recOrder:

- correctly passes the scale to the backgrounds (missed in my fixes for #426). Background acquisitions use repeated snaps, so I needed to pass the scale "manually"
- renames the background layers for compatibility with the new overlay generator
- squeezes the arrays before adding them to layers. This fixes a confusing behavior where the background would show raw data with a slider, then subsequent acquisitions would only show a retardance+orientation acquisition when the slider was at position 0. 