### PR TITLE
0.4.0 release fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Python package index](https://img.shields.io/pypi/v/recOrder-napari.svg)](https://pypi.org/project/recOrder-napari)
 [![Development Status](https://img.shields.io/pypi/status/napari.svg)](https://en.wikipedia.org/wiki/Software_release_life_cycle#Alpha)
 
-This package provides a napari plugin for quantitative label-free microscopy.
+`recOrder` is a napari plugin and command-line tool for quantitative label-free microscopy that depends on a computational optics library, [`waveorder`](https://github.com/mehta-lab/waveorder), and an I/O library, [`iohub`](https://github.com/czbiohub-sf/iohub).  
 
 In this repository you will find python tools and a napari plugin that allow the user to calibrate microscope hardware, acquire multi-modal data, reconstruct density and anisotropy, and visualize the results.
 

--- a/docs/microscope-installation-guide.md
+++ b/docs/microscope-installation-guide.md
@@ -12,7 +12,7 @@ Before you start you will need to confirm that your system is compatible with th
 
 | Software | Version |  
 | :--- | :--- |
-| `recOrder` | 0.4.x |
+| `recOrder` | 0.4.0 |
 | OS | Windows 10 | 
 | Micro-Manager version | [2023-04-26 (160 MB)](https://download.micro-manager.org/nightly/2.0/Windows/MMSetup_64bit_2.0.1_20230426.exe) | 
 | Meadowlark drivers | [USB driver (82 kB)](https://github.com/mehta-lab/recOrder/releases/download/0.4.0rc0/usbdrvd.dll) | 

--- a/docs/reconstruction-guide.md
+++ b/docs/reconstruction-guide.md
@@ -2,6 +2,17 @@
 
 `recOrder` uses a configuration-file-based command-line interface (CLI) to perform all reconstructions.
 
+## Preparing your data
+
+`recOrder` is compatible with OME-Zarr, a chunked next generation file format with an [open specification](https://ngff.openmicroscopy.org/0.4/). All acquisitions completed with the `recOrder` plugin will be automatically converted to `.zarr` format, and existing data can be converted using `iohub`'s `convert` utility. 
+
+Inside a `recOrder` environment, convert a Micro-Manager TIFF sequence, OME-TIFF, or pycromanager NDTiff datasets with
+```
+iohub convert `
+    -i ./dataset/ `
+    -o ./dataset.zarr
+```
+
 ## How can I use `recOrder`'s CLI to perform reconstructions?
 `recOrder`'s CLI is summarized in the following figure:
 <img src="./images/cli_structure.png" align="center">
@@ -39,4 +50,4 @@ The `recorder compute-tf` command accepts a list of inputs, but it only computes
 ## What types of reconstructions are supported?
 See `/recOrder/examples/` for a list of example configuration files. 
 
-TODO: Expand this documentation...need docs for each reconstruction type and parameter.
+WIP: This documentation will be expanded for each reconstruction type and parameter.

--- a/docs/reconstruction-guide.md
+++ b/docs/reconstruction-guide.md
@@ -6,7 +6,7 @@
 
 `recOrder` is compatible with OME-Zarr, a chunked next generation file format with an [open specification](https://ngff.openmicroscopy.org/0.4/). All acquisitions completed with the `recOrder` plugin will be automatically converted to `.zarr` format, and existing data can be converted using `iohub`'s `convert` utility. 
 
-Inside a `recOrder` environment, convert a Micro-Manager TIFF sequence, OME-TIFF, or pycromanager NDTiff datasets with
+Inside a `recOrder` environment, convert a Micro-Manager TIFF sequence, OME-TIFF, or pycromanager NDTiff dataset with
 ```
 iohub convert `
     -i ./dataset/ `

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,13 +45,13 @@ install_requires =
 	napari[pyqt6_experimental]
 	importlib-metadata
 	iohub==0.1.0.dev5
+	wget>=3.2
 	
 [options.extras_require]
 dev =
 	pytest>=5.0.0
 	pytest-cov
 	pytest-qt
-	wget>=3.2
 	tox
 	pre-commit
 	black


### PR DESCRIPTION
This PR contains minor fixes to prepare for the 0.4.0 release:

- Fixes #432. Documents the relationship to waveorder and iohub, and adds `iohub convert` instructions
- Depend on `wget` - because the sample contributions require it
- Updates the version number in the docs