### PR TITLE
Fix bug loading timepoints in `apply_inverse_to_zyx_and_save`

### DIFF
--- a/recOrder/cli/utils.py
+++ b/recOrder/cli/utils.py
@@ -51,11 +51,11 @@ def apply_inverse_to_zyx_and_save(
     click.echo(f"Reconstructing t={t_idx}")
 
     # Load data
-    tczyx_uint16_numpy = position.data.oindex[:, channel_indices]
+    czyx_uint16_numpy = position.data.oindex[t_idx, channel_indices]
     # convert to np.int32 (torch doesn't accept np.uint16), then convert to tensor float32
     czyx_data = torch.tensor(
-        np.int32(tczyx_uint16_numpy), dtype=torch.float32
-    )[t_idx]
+        np.int32(czyx_uint16_numpy), dtype=torch.float32
+    )
 
     # Apply transformation
     reconstruction_czyx = func(czyx_data, **kwargs)


### PR DESCRIPTION
I think I found a/the bug leading to the large memory footprint of phase reconstructions. `apply_inverse_to_zyx_and_save` would load all timepoints when processing each CZYX volume, which I think is not necessary and requires a lot of time and memory. The code works, but I haven't yet tested if this solves the multiprocessing issue.