### PR TITLE
Direct link to README image

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 `recOrder` is a collection of computational imaging methods. It currently provides QLIPP (quantitative label-free imaging with phase and polarization), phase from defocus, and fluorescence deconvolution. 
 
-[![Unveiling the invisible](./docs/images/comms_video_screenshot.png)](https://www.youtube.com/watch?v=JEZAaPeZhck)
+[![Unveiling the invisible](https://github.com/mehta-lab/recOrder/blob/main/docs/images/comms_video_screenshot.png)](https://www.youtube.com/watch?v=JEZAaPeZhck)
 
 Acquisition, calibration, background correction, reconstruction, and applications of QLIPP are described in the following [E-Life Paper](https://elifesciences.org/articles/55502):
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 `recOrder` is a collection of computational imaging methods. It currently provides QLIPP (quantitative label-free imaging with phase and polarization), phase from defocus, and fluorescence deconvolution. 
 
-[![Unveiling the invisible](https://github.com/mehta-lab/recOrder/blob/main/docs/images/comms_video_screenshot.png)](https://www.youtube.com/watch?v=JEZAaPeZhck)
+[![Unveiling the invisible](https://github.com/mehta-lab/recOrder/blob/main/docs/images/comms_video_screenshot.png?raw=true)](https://www.youtube.com/watch?v=JEZAaPeZhck)
 
 Acquisition, calibration, background correction, reconstruction, and applications of QLIPP are described in the following [E-Life Paper](https://elifesciences.org/articles/55502):
 


### PR DESCRIPTION
Here is the `0.4.1rc0` release page: https://pypi.org/project/recOrder-napari/0.4.1rc0/

I don't expect the videos to appear on PyPI since they're hosted on github (the links will download them correctly). 

This PR is an attempt to get the youtube thumbnail to appear correctly on the PyPI release page. 