### PR TITLE
Revise settings for magic-gui compatibility

### DIFF
--- a/examples/birefringence-and-phase.yml
+++ b/examples/birefringence-and-phase.yml
@@ -5,27 +5,29 @@ input_channel_names:
 - State3
 time_indices: all
 reconstruction_dimension: 3
-birefringence:
-  transfer_function:
-    swing: 0.1
-  apply_inverse:
-    wavelength_illumination: 0.532
-    background_path: ''
-    remove_estimated_background: false
-    flip_orientation: false
-    rotate_orientation: false
-phase:
-  transfer_function:
-    wavelength_illumination: 0.532
-    yx_pixel_size: 0.325
-    z_pixel_size: 2.0
-    z_padding: 0
-    index_of_refraction_media: 1.3
-    numerical_aperture_detection: 1.2
-    numerical_aperture_illumination: 0.5
-    invert_phase_contrast: false
-  apply_inverse:
-    reconstruction_algorithm: Tikhonov
-    regularization_strength: 0.001
-    TV_rho_strength: 0.001
-    TV_iterations: 1
+reconstruction_type: Birefringence and Phase
+reconstruction_settings:
+  birefringence_settings:
+    transfer_function:
+      swing: 0.1
+    apply_inverse:
+      wavelength_illumination: 0.532
+      background_path: ''
+      remove_estimated_background: false
+      flip_orientation: false
+      rotate_orientation: false
+  phase_settings:
+    transfer_function:
+      wavelength_illumination: 0.532
+      yx_pixel_size: 0.325
+      z_pixel_size: 2.0
+      z_padding: 0
+      index_of_refraction_media: 1.3
+      numerical_aperture_detection: 1.2
+      numerical_aperture_illumination: 0.5
+      invert_phase_contrast: false
+    apply_inverse:
+      reconstruction_algorithm: Tikhonov
+      regularization_strength: 0.001
+      TV_rho_strength: 0.001
+      TV_iterations: 1

--- a/examples/birefringence.yml
+++ b/examples/birefringence.yml
@@ -5,7 +5,8 @@ input_channel_names:
 - State3
 time_indices: all
 reconstruction_dimension: 3
-birefringence:
+reconstruction_type: Birefringence
+reconstruction_settings:
   transfer_function:
     swing: 0.1
   apply_inverse:

--- a/examples/fluorescence.yml
+++ b/examples/fluorescence.yml
@@ -2,7 +2,8 @@ input_channel_names:
 - GFP
 time_indices: all
 reconstruction_dimension: 3
-fluorescence:
+reconstruction_type: Fluorescence
+reconstruction_settings:
   transfer_function:
     yx_pixel_size: 0.325
     z_pixel_size: 2.0

--- a/examples/phase.yml
+++ b/examples/phase.yml
@@ -2,7 +2,8 @@ input_channel_names:
 - BF
 time_indices: all
 reconstruction_dimension: 3
-phase:
+reconstruction_type: Phase
+reconstruction_settings:
   transfer_function:
     wavelength_illumination: 0.532
     yx_pixel_size: 0.325

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -124,20 +124,21 @@ def apply_inverse_transfer_function_single_position(
         raise ValueError(
             f"time_indices = {time_indices} includes a time index beyond the maximum index of the dataset = {time_ubound}"
         )
-
-    # Simplify important settings names
-    recon_biref = settings.birefringence is not None
-    recon_phase = settings.phase is not None
-    recon_fluo = settings.fluorescence is not None
-    recon_dim = settings.reconstruction_dimension
-
+    
     # Prepare birefringence parameters
-    if settings.birefringence is not None:
+    if "Birefringence" in settings.reconstruction_type:
         # settings.birefringence has more parameters than waveorder needs,
         # so this section converts the settings to a dict and separates the
         # waveorder parameters (biref_inverse_dict) from the recorder
         # parameters (cyx_no_sample_data, and wavelength_illumination)
-        biref_inverse_dict = settings.birefringence.apply_inverse.dict()
+        if settings.reconstruction_type == "Birefringence":
+            biref_inverse_dict = (
+                settings.reconstruction_settings.apply_inverse.dict()
+            )
+        elif settings.reconstruction_type == "Birefringence and Phase":
+            biref_inverse_dict = (
+                settings.reconstruction_settings.birefringence_settings.apply_inverse.dict()
+            )
 
         # Resolve background path into array
         background_path = biref_inverse_dict.pop("background_path")
@@ -157,38 +158,38 @@ def apply_inverse_transfer_function_single_position(
     # Prepare the apply_inverse_model_function and its arguments
 
     # [biref only]
-    if recon_biref and (not recon_phase):
+    if settings.reconstruction_type == "Birefringence":
         echo_headline("Reconstructing birefringence with settings:")
-        echo_settings(settings.birefringence)
+        echo_settings(settings.reconstruction_settings)
 
         # Setup parameters for apply_inverse_to_zyx_and_save
         apply_inverse_model_function = apply_inverse_models.birefringence
         apply_inverse_args = {
             "cyx_no_sample_data": cyx_no_sample_data,
             "wavelength_illumination": biref_wavelength_illumination,
-            "recon_dim": recon_dim,
+            "recon_dim": settings.reconstruction_dimension,
             "biref_inverse_dict": biref_inverse_dict,
             "transfer_function_dataset": transfer_function_dataset,
         }
 
     # [phase only]
-    if recon_phase and (not recon_biref):
+    if settings.reconstruction_type == "Phase":
         echo_headline("Reconstructing phase with settings:")
-        echo_settings(settings.phase.apply_inverse)
+        echo_settings(settings.reconstruction_settings.apply_inverse)
 
         # Setup parameters for apply_inverse_to_zyx_and_save
         apply_inverse_model_function = apply_inverse_models.phase
         apply_inverse_args = {
-            "recon_dim": recon_dim,
-            "settings_phase": settings.phase,
+            "recon_dim": settings.reconstruction_dimension,
+            "settings_phase": settings.reconstruction_settings,
             "transfer_function_dataset": transfer_function_dataset,
         }
 
     # [biref and phase]
-    if recon_biref and recon_phase:
+    if settings.reconstruction_type == "Birefringence and Phase":
         echo_headline("Reconstructing birefringence and phase with settings:")
-        echo_settings(settings.birefringence.apply_inverse)
-        echo_settings(settings.phase.apply_inverse)
+        echo_settings(settings.reconstruction_settings.birefringence_settings.apply_inverse)
+        echo_settings(settings.reconstruction_settings.phase_settings.apply_inverse)
 
         # Setup parameters for apply_inverse_to_zyx_and_save
         apply_inverse_model_function = (
@@ -197,22 +198,22 @@ def apply_inverse_transfer_function_single_position(
         apply_inverse_args = {
             "cyx_no_sample_data": cyx_no_sample_data,
             "wavelength_illumination": biref_wavelength_illumination,
-            "recon_dim": recon_dim,
+            "recon_dim": settings.reconstruction_dimension,
             "biref_inverse_dict": biref_inverse_dict,
-            "settings_phase": settings.phase,
+            "settings_phase": settings.reconstruction_settings.phase_settings,
             "transfer_function_dataset": transfer_function_dataset,
         }
 
     # [fluo]
-    if recon_fluo:
+    if settings.reconstruction_type == "Fluorescence":
         echo_headline("Reconstructing fluorescence with settings:")
-        echo_settings(settings.fluorescence.apply_inverse)
+        echo_settings(settings.reconstruction_settings.apply_inverse)
 
         # Setup parameters for apply_inverse_to_zyx_and_save
         apply_inverse_model_function = apply_inverse_models.fluorescence
         apply_inverse_args = {
-            "recon_dim": recon_dim,
-            "settings_fluorescence": settings.fluorescence,
+            "recon_dim": settings.reconstruction_dimension,
+            "settings_fluorescence": settings.reconstruction_settings,
             "transfer_function_dataset": transfer_function_dataset,
         }
 

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -39,26 +39,21 @@ def get_reconstruction_output_metadata(position_path: Path, config_path: Path):
     T, _, Z, Y, X = input_dataset.data.shape
 
     settings = utils.yaml_to_model(config_path, ReconstructionSettings)
-
-    # Simplify important settings names
-    recon_biref = settings.birefringence is not None
-    recon_phase = settings.phase is not None
-    recon_fluo = settings.fluorescence is not None
     recon_dim = settings.reconstruction_dimension
 
     # Prepare output dataset
     channel_names = []
-    if recon_biref:
+    if "Birefringence" in settings.reconstruction_type:
         channel_names.append("Retardance")
         channel_names.append("Orientation")
         channel_names.append("BF")
         channel_names.append("Pol")
-    if recon_phase:
+    if "Phase" in settings.reconstruction_type:
         if recon_dim == 2:
             channel_names.append("Phase2D")
         elif recon_dim == 3:
             channel_names.append("Phase3D")
-    if recon_fluo:
+    if settings.reconstruction_type == "Fluorescence":
         fluor_name = settings.input_channel_names[0]
         if recon_dim == 2:
             channel_names.append(fluor_name + "_Density2D")
@@ -124,7 +119,7 @@ def apply_inverse_transfer_function_single_position(
         raise ValueError(
             f"time_indices = {time_indices} includes a time index beyond the maximum index of the dataset = {time_ubound}"
         )
-    
+
     # Prepare birefringence parameters
     if "Birefringence" in settings.reconstruction_type:
         # settings.birefringence has more parameters than waveorder needs,
@@ -188,8 +183,12 @@ def apply_inverse_transfer_function_single_position(
     # [biref and phase]
     if settings.reconstruction_type == "Birefringence and Phase":
         echo_headline("Reconstructing birefringence and phase with settings:")
-        echo_settings(settings.reconstruction_settings.birefringence_settings.apply_inverse)
-        echo_settings(settings.reconstruction_settings.phase_settings.apply_inverse)
+        echo_settings(
+            settings.reconstruction_settings.birefringence_settings.apply_inverse
+        )
+        echo_settings(
+            settings.reconstruction_settings.phase_settings.apply_inverse
+        )
 
         # Setup parameters for apply_inverse_to_zyx_and_save
         apply_inverse_model_function = (

--- a/recOrder/plugin/_widget.py
+++ b/recOrder/plugin/_widget.py
@@ -22,18 +22,10 @@ from qtpy.QtWidgets import (
 from superqt import QCollapsible, QLabeledSlider
 
 from recOrder.cli import settings
+from recOrder.cli.settings import OPTION_TO_MODEL_DICT, RECONSTRUCTION_TYPES
 
 if TYPE_CHECKING:
     from napari import Viewer
-
-OPTION_TO_MODEL_DICT = {
-    "Birefringence": settings.BirefringenceSettings,
-    "Phase": settings.PhaseSettings,
-    "Birefringence and Phase": settings.BirefringenceAndPhaseSettings,
-    "Fluorescence": settings.FluorescenceSettings,
-}
-
-RECONSTRUCTION_TYPES = Literal[tuple(OPTION_TO_MODEL_DICT.keys())]
 
 
 class QHLine(QFrame):

--- a/recOrder/plugin/_widget.py
+++ b/recOrder/plugin/_widget.py
@@ -201,7 +201,7 @@ class MainWidget(QWidget):
                     self._update_config_window
                 )
                 self.container.append(self.reconstruction_type_combo_box)
-            else:
+            elif field.name != "reconstruction_settings":
                 self.container.append(_get_config_field(field))
 
         self._update_config_window()

--- a/recOrder/tests/cli_tests/test_compute_tf.py
+++ b/recOrder/tests/cli_tests/test_compute_tf.py
@@ -1,5 +1,3 @@
-import os
-
 from click.testing import CliRunner
 
 from recOrder.cli import settings
@@ -16,8 +14,8 @@ def test_compute_transfer(tmp_path, example_plate):
     recon_settings = settings.ReconstructionSettings(
         input_channel_names=[f"State{i}" for i in range(4)],
         reconstruction_dimension=3,
-        birefringence=settings.BirefringenceSettings(),
-        phase=settings.PhaseSettings(),
+        reconstruction_type="Birefringence and Phase",
+        reconstruction_settings=settings.BirefringenceAndPhaseSettings(),
     )
     config_path = tmp_path / "test.yml"
     utils.model_to_yaml(recon_settings, config_path)

--- a/recOrder/tests/cli_tests/test_compute_tf.py
+++ b/recOrder/tests/cli_tests/test_compute_tf.py
@@ -3,6 +3,7 @@ from click.testing import CliRunner
 from recOrder.cli import settings
 from recOrder.cli.compute_transfer_function import (
     generate_and_save_birefringence_transfer_function,
+    generate_and_save_birefringence_and_phase_transfer_function,
     generate_and_save_fluorescence_transfer_function,
     generate_and_save_phase_transfer_function,
 )
@@ -61,7 +62,8 @@ def test_compute_transfer_output_file(tmp_path, example_plate):
     recon_settings = settings.ReconstructionSettings(
         input_channel_names=["BF"],
         reconstruction_dimension=3,
-        phase=settings.PhaseSettings(),
+        reconstruction_type="Phase",
+        reconstruction_settings=settings.PhaseSettings(),
     )
     config_path = tmp_path / "test.yml"
     utils.model_to_yaml(recon_settings, config_path)
@@ -90,7 +92,9 @@ def test_compute_transfer_output_file(tmp_path, example_plate):
 
 def test_stokes_matrix_write(birefringence_phase_recon_settings_function):
     settings, dataset = birefringence_phase_recon_settings_function
-    generate_and_save_birefringence_transfer_function(settings, dataset)
+    generate_and_save_birefringence_and_phase_transfer_function(
+        settings, dataset, (1, 2, 3)
+    )
     assert dataset["intensity_to_stokes_matrix"]
 
 
@@ -98,7 +102,9 @@ def test_absorption_and_phase_write(
     birefringence_phase_recon_settings_function,
 ):
     settings, dataset = birefringence_phase_recon_settings_function
-    generate_and_save_phase_transfer_function(settings, dataset, (3, 4, 5))
+    generate_and_save_birefringence_and_phase_transfer_function(
+        settings, dataset, (3, 4, 5)
+    )
     assert dataset["real_potential_transfer_function"]
     assert dataset["imaginary_potential_transfer_function"]
     assert dataset["imaginary_potential_transfer_function"].shape == (
@@ -115,7 +121,9 @@ def test_absorption_and_phase_write(
 def test_phase_3dim_write(birefringence_phase_recon_settings_function):
     settings, dataset = birefringence_phase_recon_settings_function
     settings.reconstruction_dimension = 2
-    generate_and_save_phase_transfer_function(settings, dataset, (3, 4, 5))
+    generate_and_save_birefringence_and_phase_transfer_function(
+        settings, dataset, (3, 4, 5)
+    )
     assert dataset["absorption_transfer_function"]
     assert dataset["phase_transfer_function"]
     assert dataset["phase_transfer_function"].shape == (1, 1, 3, 4, 5)

--- a/recOrder/tests/cli_tests/test_reconstruct.py
+++ b/recOrder/tests/cli_tests/test_reconstruct.py
@@ -23,12 +23,12 @@ birefringence_settings = settings.BirefringenceSettings(
     transfer_function=settings.BirefringenceTransferFunctionSettings()
 )
 
-# birefringence_option, time_indices, phase_option, dimension_option, time_length_target
+# time_indices, dimension_option, time_length_target
 all_options = [
-    (birefringence_settings, [0, 3, 4], None, 2, 5),
-    (birefringence_settings, 0, settings.PhaseSettings(), 2, 5),
-    (birefringence_settings, [0, 1], None, 3, 5),
-    (birefringence_settings, "all", settings.PhaseSettings(), 3, 5),
+    ([0, 3, 4], 2, 5),
+    (0, 2, 5),
+    ([0, 1], 3, 5),
+    ("all", 3, 5),
 ]
 
 
@@ -59,22 +59,17 @@ def test_reconstruct(tmp_input_path_zarr):
     )
 
     for i, (
-        birefringence_option,
         time_indices,
-        phase_option,
         dimension_option,
         time_length_target,
     ) in enumerate(all_options):
-        if (birefringence_option is None) and (phase_option is None):
-            continue
-
         # Generate recon settings
         recon_settings = settings.ReconstructionSettings(
             input_channel_names=channel_names,
             time_indices=time_indices,
             reconstruction_dimension=dimension_option,
-            birefringence=birefringence_option,
-            phase=phase_option,
+            reconstruction_type="Birefringence and Phase",
+            reconstruction_settings=settings.BirefringenceAndPhaseSettings(),
         )
         config_path = tmp_config_yml.with_name(f"{i}.yml")
         utils.model_to_yaml(recon_settings, config_path)
@@ -147,15 +142,10 @@ def test_cli_apply_inv_tf_output(tmp_input_path_zarr, capsys):
     input_path = tmp_input_zarr / "0" / "0" / "0"
 
     for i, (
-        birefringence_option,
         time_indices,
-        phase_option,
         dimension_option,
         time_length_target,
     ) in enumerate(all_options):
-        if (birefringence_option is None) and (phase_option is None):
-            continue
-
         result_path = tmp_input_zarr.with_name(f"result{i}.zarr").resolve()
 
         tf_path = tmp_input_zarr.with_name(f"tf_{i}.zarr")

--- a/recOrder/tests/cli_tests/test_settings.py
+++ b/recOrder/tests/cli_tests/test_settings.py
@@ -7,29 +7,11 @@ from pydantic import ValidationError
 def test_reconstruction_settings():
     # Test defaults
     s = settings.ReconstructionSettings(
-        birefringence=settings.BirefringenceSettings()
+        reconstruction_type="Birefringence",
+        reconstruction_settings=settings.BirefringenceSettings(),
     )
     assert len(s.input_channel_names) == 4
-    assert s.birefringence.apply_inverse.background_path == ""
-    assert s.phase == None
-    assert s.fluorescence == None
-
-    # Test logic that "fluorescence" or ("phase" and/or "birefringence")
-    s = settings.ReconstructionSettings(
-        input_channel_names=["GFP"],
-        birefringence=None,
-        phase=None,
-        fluorescence=settings.FluorescenceSettings(),
-    )
-
-    assert s.fluorescence.apply_inverse.reconstruction_algorithm == "Tikhonov"
-
-    # Not allowed to supply both phase/biref and fluorescence
-    with pytest.raises(ValidationError):
-        settings.ReconstructionSettings(
-            phase=settings.PhaseSettings(),
-            fluorescence=settings.FluorescenceSettings(),
-        )
+    assert s.reconstruction_settings.apply_inverse.background_path == ""
 
     # Test incorrect settings
     with pytest.raises(ValidationError):

--- a/recOrder/tests/cli_tests/test_settings.py
+++ b/recOrder/tests/cli_tests/test_settings.py
@@ -91,19 +91,22 @@ def test_generate_example_settings():
     example_path = "./examples/"
 
     s0 = settings.ReconstructionSettings(
-        birefringence=settings.BirefringenceSettings(),
-        phase=settings.PhaseSettings(),
+        reconstruction_type="Birefringence and Phase",
+        reconstruction_settings=settings.BirefringenceAndPhaseSettings(),
     )
     s1 = settings.ReconstructionSettings(
         input_channel_names=["BF"],
-        phase=settings.PhaseSettings(),
+        reconstruction_type="Phase",
+        reconstruction_settings=settings.PhaseSettings(),
     )
     s2 = settings.ReconstructionSettings(
-        birefringence=settings.BirefringenceSettings(),
+        reconstruction_type="Birefringence",
+        reconstruction_settings=settings.BirefringenceSettings(),
     )
     s3 = settings.ReconstructionSettings(
         input_channel_names=["GFP"],
-        fluorescence=settings.FluorescenceSettings(),
+        reconstruction_type="Fluorescence",
+        reconstruction_settings=settings.FluorescenceSettings(),
     )
     file_names = [
         "birefringence-and-phase.yml",

--- a/recOrder/tests/conftest.py
+++ b/recOrder/tests/conftest.py
@@ -32,9 +32,10 @@ def example_plate(tmp_path):
 @pytest.fixture(scope="function")
 def birefringence_phase_recon_settings_function(tmp_path):
     recon_settings = settings.ReconstructionSettings(
-        birefringence=settings.BirefringenceSettings(),
-        phase=settings.PhaseSettings(),
+        reconstruction_type="Birefringence and Phase",
+        reconstruction_settings=settings.BirefringenceAndPhaseSettings(),
     )
+
     dataset = open_ome_zarr(
         tmp_path,
         layout="fov",
@@ -48,7 +49,8 @@ def birefringence_phase_recon_settings_function(tmp_path):
 def fluorescence_recon_settings_function(tmp_path):
     recon_settings = settings.ReconstructionSettings(
         input_channel_names=["GFP"],
-        fluorescence=settings.FluorescenceSettings(),
+        reconstruction_type="Fluorescence",
+        reconstruction_settings=settings.FluorescenceSettings(),
     )
     dataset = open_ome_zarr(
         tmp_path,

--- a/recOrder/tests/util_tests/test_io.py
+++ b/recOrder/tests/util_tests/test_io.py
@@ -12,7 +12,8 @@ from recOrder.io.utils import add_index_to_path, model_to_yaml
 def model():
     # Create a sample model object
     return settings.ReconstructionSettings(
-        birefringence=settings.BirefringenceSettings()
+        reconstruction_type="Birefringence",
+        reconstruction_settings=settings.BirefringenceSettings(),
     )
 
 


### PR DESCRIPTION
This PR revises the pydantic settings model for compatibility with magic-gui, then updates the dependent reconstruction code and tests (which are now passing). 

See `/examples/` for the new settings layouts---only minor changes to the way that "Phase", "Birefringence", etc. modes are handled. 



