### PR TITLE
Chunk transfer functions

### DIFF
--- a/recOrder/tests/cli_tests/test_compute_tf.py
+++ b/recOrder/tests/cli_tests/test_compute_tf.py
@@ -100,17 +100,15 @@ def test_absorption_and_phase_write(
     birefringence_phase_recon_settings_function,
 ):
     settings, dataset = birefringence_phase_recon_settings_function
-    generate_and_save_phase_transfer_function(
-        settings, dataset, (100, 2000, 2001)
-    )
+    generate_and_save_phase_transfer_function(settings, dataset, (3, 4, 5))
     assert dataset["real_potential_transfer_function"]
     assert dataset["imaginary_potential_transfer_function"]
     assert dataset["imaginary_potential_transfer_function"].shape == (
         1,
         1,
-        100,
-        2000,
-        2001,
+        3,
+        4,
+        5,
     )
     assert "absorption_transfer_function" not in dataset
     assert "phase_transfer_function" not in dataset
@@ -119,12 +117,10 @@ def test_absorption_and_phase_write(
 def test_phase_3dim_write(birefringence_phase_recon_settings_function):
     settings, dataset = birefringence_phase_recon_settings_function
     settings.reconstruction_dimension = 2
-    generate_and_save_phase_transfer_function(
-        settings, dataset, (100, 2000, 2001)
-    )
+    generate_and_save_phase_transfer_function(settings, dataset, (3, 4, 5))
     assert dataset["absorption_transfer_function"]
     assert dataset["phase_transfer_function"]
-    assert dataset["phase_transfer_function"].shape == (1, 1, 100, 2000, 2001)
+    assert dataset["phase_transfer_function"].shape == (1, 1, 3, 4, 5)
     assert "real_potential_transfer_function" not in dataset
     assert "imaginary_potential_transfer_function" not in dataset
 
@@ -132,15 +128,9 @@ def test_phase_3dim_write(birefringence_phase_recon_settings_function):
 def test_fluorescence_write(fluorescence_recon_settings_function):
     settings, dataset = fluorescence_recon_settings_function
     generate_and_save_fluorescence_transfer_function(
-        settings, dataset, (100, 2000, 2001)
+        settings, dataset, (3, 4, 5)
     )
     assert dataset["optical_transfer_function"]
-    assert dataset["optical_transfer_function"].shape == (
-        1,
-        1,
-        100,
-        2000,
-        2001,
-    )
+    assert dataset["optical_transfer_function"].shape == (1, 1, 3, 4, 5)
     assert "real_potential_transfer_function" not in dataset
     assert "imaginary_potential_transfer_function" not in dataset

--- a/recOrder/tests/cli_tests/test_compute_tf.py
+++ b/recOrder/tests/cli_tests/test_compute_tf.py
@@ -100,15 +100,17 @@ def test_absorption_and_phase_write(
     birefringence_phase_recon_settings_function,
 ):
     settings, dataset = birefringence_phase_recon_settings_function
-    generate_and_save_phase_transfer_function(settings, dataset, (3, 4, 5))
+    generate_and_save_phase_transfer_function(
+        settings, dataset, (100, 2000, 2001)
+    )
     assert dataset["real_potential_transfer_function"]
     assert dataset["imaginary_potential_transfer_function"]
     assert dataset["imaginary_potential_transfer_function"].shape == (
         1,
         1,
-        3,
-        4,
-        5,
+        100,
+        2000,
+        2001,
     )
     assert "absorption_transfer_function" not in dataset
     assert "phase_transfer_function" not in dataset
@@ -117,10 +119,12 @@ def test_absorption_and_phase_write(
 def test_phase_3dim_write(birefringence_phase_recon_settings_function):
     settings, dataset = birefringence_phase_recon_settings_function
     settings.reconstruction_dimension = 2
-    generate_and_save_phase_transfer_function(settings, dataset, (3, 4, 5))
+    generate_and_save_phase_transfer_function(
+        settings, dataset, (100, 2000, 2001)
+    )
     assert dataset["absorption_transfer_function"]
     assert dataset["phase_transfer_function"]
-    assert dataset["phase_transfer_function"].shape == (1, 1, 3, 4, 5)
+    assert dataset["phase_transfer_function"].shape == (1, 1, 100, 2000, 2001)
     assert "real_potential_transfer_function" not in dataset
     assert "imaginary_potential_transfer_function" not in dataset
 
@@ -128,9 +132,15 @@ def test_phase_3dim_write(birefringence_phase_recon_settings_function):
 def test_fluorescence_write(fluorescence_recon_settings_function):
     settings, dataset = fluorescence_recon_settings_function
     generate_and_save_fluorescence_transfer_function(
-        settings, dataset, (3, 4, 5)
+        settings, dataset, (100, 2000, 2001)
     )
     assert dataset["optical_transfer_function"]
-    assert dataset["optical_transfer_function"].shape == (1, 1, 3, 4, 5)
+    assert dataset["optical_transfer_function"].shape == (
+        1,
+        1,
+        100,
+        2000,
+        2001,
+    )
     assert "real_potential_transfer_function" not in dataset
     assert "imaginary_potential_transfer_function" not in dataset


### PR DESCRIPTION
Fixes #460. Supersedes #461. Tested on @dsundarraman's reconstructions. 

This PR chunks the transfer functions along YX, matching the reconstruction chunking. 

**Details:** Writing to a .zarr with `__setitem__` (i.e. `dataset['group_name'] = myarray`) uses a single chunk, so requesting a large reconstruction failed when the chunk exceeded 2147483647 bytes. The fix is to use `create_image` instead of `__setitem__` so that we can set the chunk size.

**Notes on tests:** my first commit was a test on a large transfer function that failed locally, and my second commit fixed the problem and made the test pass locally. Unfortunately, the github action fails on this test, likely because it uses too much memory(?). My third commit reverts the test. 