### PR TITLE
Pass metadata

### DIFF
--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -1,4 +1,5 @@
 import itertools
+import warnings
 from functools import partial
 from pathlib import Path
 
@@ -34,6 +35,22 @@ def _check_background_consistency(background_shape, data_shape):
 
 
 def get_reconstruction_output_metadata(position_path: Path, config_path: Path):
+    # Get non-OME-Zarr plate-level metadata if it's available
+    plate_metadata = {}
+    try:
+        input_plate = open_ome_zarr(
+            position_path.parent.parent.parent, mode="r"
+        )
+        all_plate_metadata = dict(input_plate.zattrs)
+
+        for key in all_plate_metadata.keys():
+            if key != "plate":  # exclude OME-Zarr metadata
+                plate_metadata.append(all_plate_metadata[key])
+    except RuntimeError:
+        warnings.warn(
+            "Position is not part of a plate...no plate metadata will be copied."
+        )
+
     # Load the first position to infer dataset information
     input_dataset = open_ome_zarr(str(position_path), mode="r")
     T, _, Z, Y, X = input_dataset.data.shape
@@ -76,6 +93,7 @@ def get_reconstruction_output_metadata(position_path: Path, config_path: Path):
         "scale": input_dataset.scale,
         "channel_names": channel_names,
         "dtype": np.float32,
+        "plate_metadata": plate_metadata,
     }
 
 

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -41,11 +41,8 @@ def get_reconstruction_output_metadata(position_path: Path, config_path: Path):
         input_plate = open_ome_zarr(
             position_path.parent.parent.parent, mode="r"
         )
-        all_plate_metadata = dict(input_plate.zattrs)
-
-        for key in all_plate_metadata.keys():
-            if key != "plate":  # exclude OME-Zarr metadata
-                plate_metadata[key] = all_plate_metadata[key]
+        plate_metadata = dict(input_plate.zattrs)
+        plate_metadata.pop("plate")
     except RuntimeError:
         warnings.warn(
             "Position is not part of a plate...no plate metadata will be copied."

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -45,7 +45,7 @@ def get_reconstruction_output_metadata(position_path: Path, config_path: Path):
 
         for key in all_plate_metadata.keys():
             if key != "plate":  # exclude OME-Zarr metadata
-                plate_metadata.append(all_plate_metadata[key])
+                plate_metadata[key] = all_plate_metadata[key]
     except RuntimeError:
         warnings.warn(
             "Position is not part of a plate...no plate metadata will be copied."

--- a/recOrder/cli/utils.py
+++ b/recOrder/cli/utils.py
@@ -17,6 +17,7 @@ def create_empty_hcs_zarr(
     scale: Tuple[float],
     channel_names: list[str],
     dtype: DTypeLike,
+    plate_metadata: dict = {},
 ) -> None:
     """If the plate does not exist, create an empty zarr plate.
 
@@ -36,12 +37,17 @@ def create_empty_hcs_zarr(
     channel_names : list[str]
         Channel names, will append if not present in metadata.
     dtype : DTypeLike
+    plate_metadata : dict
     """
 
     # Create plate
     output_plate = open_ome_zarr(
         str(store_path), layout="hcs", mode="a", channel_names=channel_names
     )
+
+    # Pass metadata
+    for key in plate_metadata.keys():
+        output_plate.zattrs[key] = plate_metadata[key]
 
     # Create positions
     for position_key in position_keys:

--- a/recOrder/cli/utils.py
+++ b/recOrder/cli/utils.py
@@ -46,8 +46,7 @@ def create_empty_hcs_zarr(
     )
 
     # Pass metadata
-    for key in plate_metadata.keys():
-        output_plate.zattrs[key] = plate_metadata[key]
+    output_plate.zattrs.update(plate_metadata)
 
     # Create positions
     for position_key in position_keys:

--- a/recOrder/tests/util_tests/test_create_empty.py
+++ b/recOrder/tests/util_tests/test_create_empty.py
@@ -17,13 +17,22 @@ def test_create_empty_hcs_zarr():
     scale = (1, 1, 1, 0.5, 0.5)
     channel_names = ["Channel1", "Channel2"]
     dtype = np.uint16
+    plate_metadata = {"test": 2}
 
     create_empty_hcs_zarr(
-        store_path, position_keys, shape, chunks, scale, channel_names, dtype
+        store_path,
+        position_keys,
+        shape,
+        chunks,
+        scale,
+        channel_names,
+        dtype,
+        plate_metadata,
     )
 
     # Verify existence of positions and channels
     with open_ome_zarr(store_path, mode="r") as plate:
+        assert plate.zattrs["test"] == 2
         for position_key in position_keys:
             position = plate["/".join(position_key)]
             assert isinstance(position, Position)


### PR DESCRIPTION
**Before:** `recorder reconstruct` does not pass any plate-level metadata because it takes single position as input. This was very inconvenient for @dsundarraman's work, where we need to reconstruct each FOV then use the plate-level stage-position metatdata for a first pass at stitching the FOVs. 

**After:** `recorder reconstruct` checks to see if the position is a part of a plate, and passes the plate-level metadata if is.  

---

@dsundarraman, this PR will let you run reconstructions, then merge the reconstructions directly. Here's a snippet to get you started...I expect these to be some of the first lines in `zebrapro stitch`:
```
plate = open_ome_zarr("./reconstruction.zarr")
positions = plate.zattrs["Summary"]["StagePositions"]
zyx_stage_position_list = [[positions[k]["DevicePositions"][0]["Position_um"][0], positions[k]["DevicePositions"][1]["Position_um"][0], positions[k]["DevicePositions"][1]["Position_um"][1]] for k in range(len(positions))]
```