### PR TITLE
Fix background check bug

### DIFF
--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -1,4 +1,5 @@
 import itertools
+import warnings
 from functools import partial
 from pathlib import Path
 
@@ -34,6 +35,22 @@ def _check_background_consistency(background_shape, data_shape):
 
 
 def get_reconstruction_output_metadata(position_path: Path, config_path: Path):
+    # Get non-OME-Zarr plate-level metadata if it's available
+    plate_metadata = {}
+    try:
+        input_plate = open_ome_zarr(
+            position_path.parent.parent.parent, mode="r"
+        )
+        all_plate_metadata = dict(input_plate.zattrs)
+
+        for key in all_plate_metadata.keys():
+            if key != "plate":  # exclude OME-Zarr metadata
+                plate_metadata.append(all_plate_metadata[key])
+    except RuntimeError:
+        warnings.warn(
+            "Position is not part of a plate...no plate metadata will be copied."
+        )
+
     # Load the first position to infer dataset information
     input_dataset = open_ome_zarr(str(position_path), mode="r")
     T, _, Z, Y, X = input_dataset.data.shape
@@ -76,6 +93,7 @@ def get_reconstruction_output_metadata(position_path: Path, config_path: Path):
         "scale": input_dataset.scale,
         "channel_names": channel_names,
         "dtype": np.float32,
+        "plate_metadata": plate_metadata,
     }
 
 

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -29,7 +29,7 @@ from recOrder.io import utils
 def _check_background_consistency(background_shape, data_shape):
     data_cyx_shape = (data_shape[1],) + data_shape[3:]
     if background_shape != data_cyx_shape:
-        raise ValueError(
+        warnings.warn(
             f"Background shape {background_shape} does not match data shape {data_cyx_shape}"
         )
 

--- a/recOrder/cli/apply_inverse_transfer_function.py
+++ b/recOrder/cli/apply_inverse_transfer_function.py
@@ -45,7 +45,7 @@ def get_reconstruction_output_metadata(position_path: Path, config_path: Path):
 
         for key in all_plate_metadata.keys():
             if key != "plate":  # exclude OME-Zarr metadata
-                plate_metadata.append(all_plate_metadata[key])
+                plate_metadata[key] = all_plate_metadata[key]
     except RuntimeError:
         warnings.warn(
             "Position is not part of a plate...no plate metadata will be copied."

--- a/recOrder/cli/utils.py
+++ b/recOrder/cli/utils.py
@@ -17,6 +17,7 @@ def create_empty_hcs_zarr(
     scale: Tuple[float],
     channel_names: list[str],
     dtype: DTypeLike,
+    plate_metadata: dict = {},
 ) -> None:
     """If the plate does not exist, create an empty zarr plate.
 
@@ -36,12 +37,17 @@ def create_empty_hcs_zarr(
     channel_names : list[str]
         Channel names, will append if not present in metadata.
     dtype : DTypeLike
+    plate_metadata : dict
     """
 
     # Create plate
     output_plate = open_ome_zarr(
         str(store_path), layout="hcs", mode="a", channel_names=channel_names
     )
+
+    # Pass metadata
+    for key in plate_metadata.keys():
+        output_plate.zattrs[key] = plate_metadata[key]
 
     # Create positions
     for position_key in position_keys:

--- a/recOrder/tests/util_tests/test_create_empty.py
+++ b/recOrder/tests/util_tests/test_create_empty.py
@@ -17,13 +17,22 @@ def test_create_empty_hcs_zarr():
     scale = (1, 1, 1, 0.5, 0.5)
     channel_names = ["Channel1", "Channel2"]
     dtype = np.uint16
+    plate_metadata = {"test": 2}
 
     create_empty_hcs_zarr(
-        store_path, position_keys, shape, chunks, scale, channel_names, dtype
+        store_path,
+        position_keys,
+        shape,
+        chunks,
+        scale,
+        channel_names,
+        dtype,
+        plate_metadata,
     )
 
     # Verify existence of positions and channels
     with open_ome_zarr(store_path, mode="r") as plate:
+        assert plate.zattrs["test"] == 2
         for position_key in position_keys:
             position = plate["/".join(position_key)]
             assert isinstance(position, Position)


### PR DESCRIPTION
When reconstructing a dataset with both polarization and fluorescence, this assertion causes issues. 