### PR TITLE
Default HSV colormap

### DIFF
--- a/recOrder/io/utils.py
+++ b/recOrder/io/utils.py
@@ -8,6 +8,7 @@ import yaml
 from iohub import open_ome_zarr
 
 
+
 def add_index_to_path(path: Path):
     """Takes a path to a file or folder and appends the smallest index that does
     not already exist in that folder.

--- a/recOrder/io/utils.py
+++ b/recOrder/io/utils.py
@@ -133,7 +133,7 @@ def ret_ori_overlay(
     retardance,
     orientation,
     ret_max: Union[float, Literal["auto"]] = 10,
-    cmap: Literal["JCh", "HSV"] = "JCh",
+    cmap: Literal["JCh", "HSV"] = "HSV",
 ):
     """
     This function will create an overlay of retardance and orientation with two different colormap options.

--- a/recOrder/io/visualization.py
+++ b/recOrder/io/visualization.py
@@ -11,7 +11,7 @@ def ret_ori_overlay(
     czyx,
     ret_min: float = 1,
     ret_max: Union[float, Literal["auto"]] = 10,
-    cmap: Literal["JCh", "HSV"] = "JCh",
+    cmap: Literal["JCh", "HSV"] = "HSV",
 ):
     """
     Creates an overlay of retardance and orientation with two different colormap options.

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ acq =
 	pyqtgraph>=0.12.3
 	napari-ome-zarr>=0.3.2 # drag and drop convenience
 	ome-zarr==0.8.3 # unpin when resolved: https://github.com/ome/napari-ome-zarr/issues/111
-	napari[pyqt6_experimental]
+	napari[pyqt6]
 
 [options.package_data]
 * = *.yaml


### PR DESCRIPTION
We typically expect HSV colormaps, so I'm changing the `ret_ori_overlay` function's default.

@edyoshikun related to: https://github.com/czbiohub-sf/shrimPy/pull/141

