### PR TITLE
Pin ome-zarr

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -59,6 +59,7 @@ acq =
 	pycromanager==0.27.2
 	pyqtgraph>=0.12.3
 	napari-ome-zarr>=0.3.2 # drag and drop convenience
+	ome-zarr==0.8.3 # unpin when resolved: https://github.com/ome/napari-ome-zarr/issues/111
 	napari[pyqt6_experimental]
 
 [options.package_data]


### PR DESCRIPTION
Related https://github.com/ome/napari-ome-zarr/issues/111.

The latest versions of ome-zarr do not allow the napari plugin to read the channel names correctly. `recOrder` needs the channel names to generate birefringence overlays, so I'm pinning to an old version until this is fixed.  