### PR TITLE
Do not require MicroManager group to be named "Channel"

### DIFF
--- a/recOrder/plugin/main_widget.py
+++ b/recOrder/plugin/main_widget.py
@@ -922,7 +922,7 @@ class MainWidget(QWidget):
         loaded_devices = [_devices.get(i) for i in range(_devices.size())]
         if LC_DEVICE_NAME in loaded_devices:
             config_desc = self.mmc.getConfigData(
-                "Channel", "State0"
+                self.config_group, "State0"
             ).getVerbose()
             if "String send to" in config_desc:
                 self.calib_mode = "MM-Retardance"


### PR DESCRIPTION
Fixes mehta-lab/waveorder#203.

This PR fixes a bug that required the MicroManager group to be named "Channel" to establish a pycromanager connection.   

I have not tested this PR, and it will need to be tested at a microscope before merging.  