### PR TITLE
Update badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # recOrder
+[![Python package index](https://img.shields.io/pypi/v/waveorder.svg)](https://pypi.org/project/recOrder-napari)
+[![PyPI monthly downloads](https://img.shields.io/pypi/dm/waveorder.svg)](https://pypistats.org/packages/recOrder-napari)
+[![Total downloads](https://pepy.tech/badge/recOrder-napari)](https://pepy.tech/project/recOrder-napari)
+[![GitHub contributors](https://img.shields.io/github/contributors-anon/mehta-lab/recOrder)](https://github.com/mehta-lab/recOrder/graphs/contributors)
+![GitHub Repo stars](https://img.shields.io/github/stars/mehta-lab/recOrder)
+![GitHub forks](https://img.shields.io/github/forks/mehta-lab/recOrder)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/recOrder-napari)
-[![Python package index download statistics](https://img.shields.io/pypi/dm/recOrder-napari.svg)](https://pypistats.org/packages/recOrder-napari)
-[![Python package index](https://img.shields.io/pypi/v/recOrder-napari.svg)](https://pypi.org/project/recOrder-napari)
-[![Development Status](https://img.shields.io/pypi/status/napari.svg)](https://en.wikipedia.org/wiki/Software_release_life_cycle#Alpha)
+
+
 
 `recOrder` is a collection of computational imaging methods. It currently provides QLIPP (quantitative label-free imaging with phase and polarization), phase from defocus, and fluorescence deconvolution. 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # recOrder
-[![Python package index](https://img.shields.io/pypi/v/waveorder.svg)](https://pypi.org/project/recOrder-napari)
-[![PyPI monthly downloads](https://img.shields.io/pypi/dm/waveorder.svg)](https://pypistats.org/packages/recOrder-napari)
+[![Python package index](https://img.shields.io/pypi/v/recOrder-napari.svg)](https://pypi.org/project/recOrder-napari)
+[![PyPI monthly downloads](https://img.shields.io/pypi/dm/recOrder-napari.svg)](https://pypistats.org/packages/recOrder-napari)
 [![Total downloads](https://pepy.tech/badge/recOrder-napari)](https://pepy.tech/project/recOrder-napari)
 [![GitHub contributors](https://img.shields.io/github/contributors-anon/mehta-lab/recOrder)](https://github.com/mehta-lab/recOrder/graphs/contributors)
 ![GitHub Repo stars](https://img.shields.io/github/stars/mehta-lab/recOrder)


### PR DESCRIPTION
This PR updates recOrder's badges to match [viscy](https://github.com/mehta-lab/VisCy) and [waveorder (badges merging soon)](https://github.com/mehta-lab/waveorder/blob/e465119c0a3c7a194a8405d909560ed20c1b5c4f/README.md).