### PR TITLE
iohub dependency update

### DIFF
--- a/recOrder/cli/utils.py
+++ b/recOrder/cli/utils.py
@@ -4,8 +4,7 @@ from typing import Tuple
 import click
 import numpy as np
 import torch
-from iohub.ngff import Position, open_ome_zarr
-from iohub.ngff_meta import TransformationMeta
+from iohub.ngff import Position, TransformationMeta, open_ome_zarr
 from numpy.typing import DTypeLike
 
 
@@ -103,4 +102,3 @@ def apply_inverse_to_zyx_and_save(
             t_idx, output_channel_indices
         ] = reconstruction_czyx
     click.echo(f"Finished Writing.. t={t_idx}")
-


### PR DESCRIPTION
This is a one-line fix for a bug we encountered with recOrder when testing it with the main branch of iohub. This branch can optionally be merged here. On the waveorder repo we'll need this fix together with updated `iohub` and `pydantic` dependencies. See [`waveorder` #197](https://github.com/mehta-lab/waveorder/issues/197).